### PR TITLE
fix redirection rules

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -1,6014 +1,6009 @@
 {
-    "redirections": [{
-            "source_path": "reference/docs-conceptual/dsc/tutorials/dscCiCd.md",
-            "redirect_url": "/azure/devops/pipelines/get-started/dsc-cicd",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/docs-conceptual/index.md",
-            "redirect_url": "/powershell/scripting/overview",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "digital-art.md",
-            "redirect_url": "/powershell/scripting/community/digital-art",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/digital-art.md",
-            "redirect_url": "/powershell/scripting/community/digital-art",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/docs-conceptual/community/whats-new-in-docs.md",
-            "redirect_url": "/powershell/scripting/community/community-update",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/index.md",
-            "redirect_url": "/powershell/scripting/developer/windows-powershell",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/dsc/index.md",
-            "redirect_url": "/powershell/scripting/dsc/overview/decisionmaker",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/gallery/index.md",
-            "redirect_url": "/powershell/scripting/gallery/overview",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/index.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/overview",
-            "redirect_document_id": true
-        },
-
-
-        {
-            "source_path": "reference/docs-conceptual/dsc/getting-started/azuredscexthistory.md",
-            "redirect_url": "/azure/automation/automation-dsc-extension-history",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/docs-conceptual/dsc/getting-started/azuredsc.md",
-            "redirect_url": "/azure/automation/automation-dsc-getting-started",
-            "redirect_document_id": false
-        },
-
-
-        {
-            "source_path": "reference/docs-conceptual/whats-new/experimental-features.md",
-            "redirect_url": "/powershell/scripting/learn/experimental-features",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/learn/ps101/Getting-Detailed-Help-Information.md",
-            "redirect_url": "/powershell/scripting/learn/ps101/02-help-system",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/docs-conceptual/learn/ps101/Getting-Information-About-Commands.md",
-            "redirect_url": "/powershell/scripting/learn/ps101/02-help-system",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/docs-conceptual/learn/ps101/Learning-PowerShell-Names.md",
-            "redirect_url": "/powershell/scripting/learn/ps101/02-help-system",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/docs-conceptual/learn/ps101/PowerShell.exe-Command-Line-Help.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_powershell_exe",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/docs-conceptual/learn/ps101/Using-Familiar-Command-Names.md",
-            "redirect_url": "/powershell/scripting/learn/ps101/05-formatting-aliases-providers-comparison",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/docs-conceptual/learn/ps101/Using-Variables-to-Store-Objects.md",
-            "redirect_url": "/powershell/scripting/learn/ps101/03-discovering-objects",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/docs-conceptual/learn/ps101/Using-Tab-Expansion.md",
-            "redirect_url": "/powershell/scripting/learn/Using-Tab-Expansion",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/console/using-tab-expansion.md",
-            "redirect_url": "/powershell/scripting/learn/ps101/using-tab-expansion",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/learn/getting-detailed-help-information.md",
-            "redirect_url": "/powershell/scripting/learn/ps101/02-help-system",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/docs-conceptual/learn/getting-information-about-commands.md",
-            "redirect_url": "/powershell/scripting/learn/ps101/02-help-system",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/docs-conceptual/learn/learning-powershell-names.md",
-            "redirect_url": "/powershell/scripting/learn/ps101/02-help-system",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/docs-conceptual/learn/using-familiar-command-names.md",
-            "redirect_url": "/powershell/scripting/learn/ps101/05-formatting-aliases-providers-comparison",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/learn/using-variables-to-store-objects.md",
-            "redirect_url": "/powershell/scripting/learn/ps101/03-discovering-objects",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/whats-new/migrating-from-windows-powershell-51-to-powershell-7.md",
-            "redirect_url": "/powershell/scripting/install/migrating-from-windows-powershell-51-to-powershell-7",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/whats-new/what-s-new-in-the-powershell-50-ise.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/whats-new/what-s-new-in-the-powershell-50-ise",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/whats-new/what-s-new-in-windows-powershell-50.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/whats-new/what-s-new-in-windows-powershell-50",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/cmdlet/writing-a-windows-powershell-cmdlet.md",
-            "redirect_url": "/powershell/scripting/developer/cmdlet/cmdlet-overview",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/format/examples-of-formatting-files.md",
-            "redirect_url": "/powershell/scripting/developer/format/wide-view-basic",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/format/writing-a-powershell-formatting-file.md",
-            "redirect_url": "/powershell/scripting/developer/format/formatting-file-overview",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/hosting/writing-a-windows-powershell-host-application.md",
-            "redirect_url": "/powershell/scripting/developer/hosting/windows-powershell-host-quickstart",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/provider/writing-a-windows-powershell-provider.md",
-            "redirect_url": "/powershell/scripting/developer/provider/windows-powershell-provider-quickstart",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/getting-started/getting-started-with-windows-powershell.md",
-            "redirect_url": "/powershell/scripting/overview",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/docs-conceptual/install/installing-windows-powershell.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/install/installing-windows-powershell",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/learn/understanding-important-powershell-concepts.md",
-            "redirect_url": "/powershell/scripting/overview",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/docs-conceptual/learn/understanding-the-powershell-pipeline.md",
-            "redirect_url": "/powershell/scripting/overview",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/docs-conceptual/install/windows-powershell-system-requirements.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/install/windows-powershell-system-requirements",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/accessibility-in-windows-powershell-ise.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/accessibility-in-windows-powershell-ise",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/exploring-the-windows-powershell-ise.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/exploring-the-windows-powershell-ise",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/how-to-create-a-powershell-tab-in-windows-powershell-ise.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/how-to-create-a-powershell-tab-in-windows-powershell-ise",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/how-to-debug-scripts-in-windows-powershell-ise.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/how-to-debug-scripts-in-windows-powershell-ise",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/how-to-use-profiles-in-windows-powershell-ise.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/how-to-use-profiles-in-windows-powershell-ise",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/how-to-use-tab-completion-in-the-script-pane-and-console-pane.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/how-to-use-tab-completion-in-the-script-pane-and-console-pane",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/how-to-use-the-console-pane-in-the-windows-powershell-ise.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/how-to-use-the-console-pane-in-the-windows-powershell-ise",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/how-to-write-and-run-scripts-in-the-windows-powershell-ise.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/how-to-write-and-run-scripts-in-the-windows-powershell-ise",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/introducing-the-windows-powershell-ise.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/introducing-the-windows-powershell-ise",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/keyboard-shortcuts-for-the-windows-powershell-ise.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/keyboard-shortcuts-for-the-windows-powershell-ise",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/object-model/purpose-of-the-windows-powershell-ise-scripting-object-model.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/purpose-of-the-windows-powershell-ise-scripting-object-model",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/object-model/the-iseaddontoolcollection-object.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-iseaddontoolcollection-object",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/object-model/the-iseaddontool-object.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-iseaddontool-object",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/object-model/the-iseeditor-object.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-iseeditor-object",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/object-model/the-isefilecollection-object.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-isefilecollection-object",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/object-model/the-isefile-object.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-isefile-object",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/object-model/the-isemenuitemcollection-object.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-isemenuitemcollection-object",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/object-model/the-isemenuitem-object.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-isemenuitem-object",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/object-model/the-ise-object-model-hierarchy.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-ise-object-model-hierarchy",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/object-model/the-iseoptions-object.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-iseoptions-object",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/object-model/the-isesnippetcollection-object.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-isesnippetcollection-object",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/object-model/the-isesnippetobject.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-isesnippetobject",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/object-model/the-objectmodelroot-object.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-objectmodelroot-object",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/object-model/the-powershelltabcollection-object.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-powershelltabcollection-object",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/ise/object-model/the-powershelltab-object.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-powershelltab-object",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/vscode/how-to-replicate-the-ise-experience-in-vscode.md",
-            "redirect_url": "/powershell/scripting/dev-cross-plat/vscode/how-to-replicate-the-ise-experience-in-vscode",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/vscode/understanding-file-encoding.md",
-            "redirect_url": "/powershell/scripting/dev-cross-plat/vscode/understanding-file-encoding",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/vscode/using-vscode.md",
-            "redirect_url": "/powershell/scripting/dev-cross-plat/vscode/using-vscode",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/components/vscode/using-vscode-for-remote-editing-and-debugging.md",
-            "redirect_url": "/powershell/scripting/dev-cross-plat/vscode/using-vscode-for-remote-editing-and-debugging",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/cmdlet/how-to-create-a-windows-powershell-snap-in.md",
-            "redirect_url": "/powershell/scripting/developer/module/how-to-create-a-windows-powershell-snap-in",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/cmdlet/how-to-import-cmdlets-using-modules.md",
-            "redirect_url": "/powershell/scripting/developer/module/how-to-import-cmdlets-using-modules",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/cmdlet/modules-and-snap-ins.md",
-            "redirect_url": "/powershell/scripting/developer/module/modules-and-snap-ins",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/cmdlet/registering-cmdlets.md",
-            "redirect_url": "/powershell/scripting/developer/module/registering-cmdlets",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/cmdlet/writing-a-custom-windows-powershell-snap-in.md",
-            "redirect_url": "/powershell/scripting/developer/module/writing-a-custom-windows-powershell-snap-in",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/cmdlet/writing-a-windows-powershell-snap-in.md",
-            "redirect_url": "/powershell/scripting/developer/module/writing-a-windows-powershell-snap-in",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/module/file-types-permitted-in-an-updatable-help-cab-file.md",
-            "redirect_url": "/powershell/scripting/developer/help/file-types-permitted-in-an-updatable-help-cab-file",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/module/helpinfo-xml-sample-file.md",
-            "redirect_url": "/powershell/scripting/developer/help/helpinfo-xml-sample-file",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/module/helpinfo-xml-schema.md",
-            "redirect_url": "/powershell/scripting/developer/help/helpinfo-xml-schema",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/module/how-to-create-a-helpinfo-xml-file.md",
-            "redirect_url": "/powershell/scripting/developer/help/how-to-create-a-helpinfo-xml-file",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/module/how-to-create-and-upload-cab-files.md",
-            "redirect_url": "/powershell/scripting/developer/help/how-to-create-and-upload-cab-files",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/module/how-to-name-a-helpinfo-xml-file.md",
-            "redirect_url": "/powershell/scripting/developer/help/how-to-name-a-helpinfo-xml-file",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/module/how-to-name-an-updatable-help-cab-file.md",
-            "redirect_url": "/powershell/scripting/developer/help/how-to-name-an-updatable-help-cab-file",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/module/how-to-prepare-updatable-help-cab-files.md",
-            "redirect_url": "/powershell/scripting/developer/help/how-to-prepare-updatable-help-cab-files",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/module/how-to-set-helpinfo-xml-version-numbers.md",
-            "redirect_url": "/powershell/scripting/developer/help/how-to-set-helpinfo-xml-version-numbers",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/module/how-to-test-updatable-help.md",
-            "redirect_url": "/powershell/scripting/developer/help/how-to-test-updatable-help",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/module/how-to-update-help-files.md",
-            "redirect_url": "/powershell/scripting/developer/help/how-to-update-help-files",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/module/how-updatable-help-works.md",
-            "redirect_url": "/powershell/scripting/developer/help/how-updatable-help-works",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/module/naming-help-files.md",
-            "redirect_url": "/powershell/scripting/developer/help/naming-help-files",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/module/supporting-online-help.md",
-            "redirect_url": "/powershell/scripting/developer/help/supporting-online-help",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/module/supporting-updatable-help.md",
-            "redirect_url": "/powershell/scripting/developer/help/supporting-updatable-help",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/module/updatable-help-authoring-step-by-step.md",
-            "redirect_url": "/powershell/scripting/developer/help/updatable-help-authoring-step-by-step",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/module/updatable-help-overview.md",
-            "redirect_url": "/powershell/scripting/developer/help/updatable-help-overview",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/developer/module/writing-help-for-windows-powershell-modules.md",
-            "redirect_url": "/powershell/scripting/developer/help/writing-help-for-windows-powershell-modules",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/getting-started/starting-the-windows-powershell-2.0-engine.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/starting-the-windows-powershell-2.0-engine",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/getting-started/starting-windows-powershell.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/starting-windows-powershell",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/install/installing-the-windows-powershell-2.0-engine.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/install/installing-the-windows-powershell-2.0-engine",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/learn/windows-powershell-glossary.md",
-            "redirect_url": "/powershell/scripting/learn/glossary",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/learn/writing-portable-modules.md",
-            "redirect_url": "/powershell/scripting/dev-cross-plat/writing-portable-modules",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/known-issues/known-issues-50.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/known-issues/known-issues-50",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/known-issues/known-issues-51.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/known-issues/known-issues-51",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/known-issues/known-issues-dsc.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/known-issues/known-issues-dsc",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/overview.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/overview",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/setup/install-configure.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/setup/install-configure",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/setup/uninstall.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/setup/uninstall",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/whats-new/bugfixes.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/bugfixes",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/whats-new/class-overview.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/class-overview",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/whats-new/compatibility.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/compatibility",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/whats-new/console-improvements.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/console-improvements",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/whats-new/debug-overview.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/debug-overview",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/whats-new/dsc-improvements.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/dsc-improvements",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/whats-new/engine-improvements.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/engine-improvements",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/whats-new/informationstream-overview.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/informationstream-overview",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/whats-new/jea-improvements.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/jea-improvements",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/whats-new/new-updated-cmdlets.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/new-updated-cmdlets",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/whats-new/package-management-improvements.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/package-management-improvements",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/whats-new/release-notes.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/release-notes",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/whats-new/script-logging.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/script-logging",
-            "redirect_document_id": true
-        },
-        {
-            "source_path": "reference/docs-conceptual/wmf/whats-new/sil-overview.md",
-            "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/sil-overview",
-            "redirect_document_id": true
-        },
-
-
-        {
-            "source_path": "reference/virtual-directory-module/5.1/ise.md",
-            "redirect_url": "/powershell/module/ise/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/ise/get-isesnippet.md",
-            "redirect_url": "/powershell/module/ise/get-isesnippet",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/ise/import-isesnippet.md",
-            "redirect_url": "/powershell/module/ise/import-isesnippet",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/ise/ise.md",
-            "redirect_url": "/powershell/module/ise/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/ise/new-isesnippet.md",
-            "redirect_url": "/powershell/module/ise/new-isesnippet",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.archive.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.archive/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.archive/compress-archive.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.archive/compress-archive",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.archive/expand-archive.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.archive/expand-archive",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.archive/microsoft.powershell.archive.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.archive/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_aliases.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_aliases",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_arithmetic_operators.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_arithmetic_operators",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_arrays.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_arrays",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_assignment_operators.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_assignment_operators",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_automatic_variables.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_automatic_variables",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_break.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_break",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_classes.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_classes",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_command_precedence.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_command_precedence",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_command_syntax.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_command_syntax",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_comment_based_help.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_comment_based_help",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_commonparameters.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_commonparameters",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_comparison_operators.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_comparison_operators",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_continue.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_continue",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_core_commands.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_core_commands",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_data_sections.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_data_sections",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_debuggers.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_debuggers",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_desiredstateconfiguration.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_desiredstateconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_do.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_do",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_dsclogresource.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_dsclogresource",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_enum.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_enum",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_environment_variables.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_environment_variables",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_escape_characters.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_special_characters",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_eventlogs.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_eventlogs",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_execution_policies.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_execution_policies",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_for.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_for",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_foreach.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_foreach",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_format.ps1xml.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_format.ps1xml",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_functions.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_functions_advanced.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_advanced",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_functions_advanced_methods.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_advanced_methods",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_functions_advanced_parameters.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_functions_cmdletbindingattribute.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_cmdletbindingattribute",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_functions_outputtypeattribute.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_outputtypeattribute",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_group_policy_settings.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_group_policy_settings",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_hash_tables.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_hash_tables",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_hidden.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_hidden",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_history.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_history",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_if.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_if",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_job_details.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_job_details",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_jobs.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_jobs",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_join.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_join",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_language_keywords.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_language_keywords",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_language_modes.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_language_modes",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_line_editing.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_line_editing",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_locations.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_locations",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_logical_operators.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_logical_operators",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_methods.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_methods",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_modules.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_modules",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_object_creation.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_object_creation",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_objects.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_objects",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_operator_precedence.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_operator_precedence",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_operators.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_operators",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_packagemanagement.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_packagemanagement",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_parameters.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_parameters",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_parameters_default_values.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_parameters_default_values",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_parsing.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_parsing",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_path_syntax.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_path_syntax",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_pipelines.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pipelines",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_powershell_exe.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_powershell_exe",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_powershell_ise_exe.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_powershell_ise_exe",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_preference_variables.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_preference_variables",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_profiles.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_profiles",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_prompts.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_prompts",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_properties.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_properties",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_providers.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_providers",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_psconsolehostreadline.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_psconsolehostreadline",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_psreadline.md",
-            "redirect_url": "/powershell/module/psreadline/about/about_psreadline",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_pssession_details.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pssession_details",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_pssessions.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pssessions",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_pssnapins.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pssnapins",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_quoting_rules.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_quoting_rules",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_redirection.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_redirection",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_ref.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_ref",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_regular_expressions.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_regular_expressions",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_remote.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_remote_disconnected_sessions.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_disconnected_sessions",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_remote_faq.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_faq",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_remote_jobs.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_jobs",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_remote_output.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_output",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_remote_requirements.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_requirements",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_remote_troubleshooting.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_troubleshooting",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_remote_variables.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_variables",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_requires.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_requires",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_reserved_words.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_reserved_words",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_return.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_return",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_run_with_powershell.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_run_with_powershell",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_scopes.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_scopes",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_script_blocks.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_script_blocks",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_script_internationalization.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_script_internationalization",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_scripts.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_scripts",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_session_configuration_files.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_session_configuration_files",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_session_configurations.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_session_configurations",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_signing.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_signing",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_simplified_syntax.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_simplified_syntax",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_special_characters.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_special_characters",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_splatting.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_splatting",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_split.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_split",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_switch.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_switch",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_throw.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_throw",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_transactions.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_transactions",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_trap.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_trap",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_try_catch_finally.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_try_catch_finally",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_type_accelerators.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_type_accelerators",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_type_operators.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_type_operators",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_types.ps1xml.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_types.ps1xml",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_updatable_help.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_updatable_help",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_variables.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_variables",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_while.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_while",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_wildcards.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_wildcards",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_windows_powershell_5.1.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_windows_powershell_5.1",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_windows_powershell_ise.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_windows_powershell_ise",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_windows_rt.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_windows_rt",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_wmi.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_wmi",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_wmi_cmdlets.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_wmi_cmdlets",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_wql.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_wql",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/add-history.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/add-history",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/add-pssnapin.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/add-pssnapin",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/alias-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_alias_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/clear-history.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/clear-history",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/connect-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/connect-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/debug-job.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/debug-job",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/disable-psremoting.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/disable-psremoting",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/disable-pssessionconfiguration.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/disable-pssessionconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/disconnect-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/disconnect-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/enable-psremoting.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/enable-psremoting",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/enable-pssessionconfiguration.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/enable-pssessionconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/enter-pshostprocess.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/enter-pshostprocess",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/enter-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/enter-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/environment-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_environment_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/exit-pshostprocess.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/exit-pshostprocess",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/exit-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/exit-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/export-console.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/export-console",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/export-modulemember.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/export-modulemember",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/filesystem-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_filesystem_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/foreach-object.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/foreach-object",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/function-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_function_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/functions/clear-host.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/clear-host",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/clear-host.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/clear-host",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/functions/get-verb.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-verb",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-verb.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-verb",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-command.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-command",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-help.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-help",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-history.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-history",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-job.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-job",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-module.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-pshostprocessinfo.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-pshostprocessinfo",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-pssessioncapability.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-pssessioncapability",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-pssessionconfiguration.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-pssessionconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-pssnapin.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-pssnapin",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/import-module.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/import-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/invoke-command.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/invoke-command",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/invoke-history.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/invoke-history",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/microsoft.powershell.core.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/new-module.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/new-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/new-modulemanifest.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/new-modulemanifest",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/new-psrolecapabilityfile.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/new-psrolecapabilityfile",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/new-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/new-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/new-pssessionconfigurationfile.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/new-pssessionconfigurationfile",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/new-pssessionoption.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/new-pssessionoption",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/new-pstransportoption.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/new-pstransportoption",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/out-default.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/out-default",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/out-host.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/out-host",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/out-null.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/out-null",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/receive-job.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/receive-job",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/receive-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/receive-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/register-argumentcompleter.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/register-argumentcompleter",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/register-pssessionconfiguration.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/register-pssessionconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/registry-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_registry_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/remove-job.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/remove-job",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/remove-module.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/remove-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/remove-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/remove-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/remove-pssnapin.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/remove-pssnapin",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/resume-job.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/resume-job",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/save-help.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/save-help",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/set-psdebug.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/set-psdebug",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/set-pssessionconfiguration.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/set-pssessionconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/set-strictmode.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/set-strictmode",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/start-job.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/start-job",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/stop-job.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/stop-job",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/suspend-job.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/suspend-job",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/test-modulemanifest.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/test-modulemanifest",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/test-pssessionconfigurationfile.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/test-pssessionconfigurationfile",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/unregister-pssessionconfiguration.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/unregister-pssessionconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/update-help.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/update-help",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/variable-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_variable_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/wait-job.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/wait-job",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/where-object.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/where-object",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.diagnostics.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.diagnostics/export-counter.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/export-counter",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.diagnostics/get-counter.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/get-counter",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.diagnostics/get-winevent.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/get-winevent",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.diagnostics/import-counter.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/import-counter",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.diagnostics/microsoft.powershell.diagnostics.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.diagnostics/new-winevent.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/new-winevent",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.host.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.host/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.host/microsoft.powershell.host.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.host/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.host/start-transcript.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.host/start-transcript",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.host/stop-transcript.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.host/stop-transcript",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/add-localgroupmember.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/add-localgroupmember",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/disable-localuser.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/disable-localuser",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/enable-localuser.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/enable-localuser",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/get-localgroup.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/get-localgroup",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/get-localgroupmember.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/get-localgroupmember",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/get-localuser.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/get-localuser",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/microsoft.powershell.localaccounts.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/new-localgroup.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/new-localgroup",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/new-localuser.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/new-localuser",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/remove-localgroup.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/remove-localgroup",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/remove-localgroupmember.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/remove-localgroupmember",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/remove-localuser.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/remove-localuser",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/rename-localgroup.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/rename-localgroup",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/rename-localuser.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/rename-localuser",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/set-localgroup.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/set-localgroup",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/set-localuser.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/set-localuser",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/add-computer.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/add-computer",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/add-content.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/add-content",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/checkpoint-computer.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/checkpoint-computer",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/clear-content.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/clear-content",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/clear-eventlog.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/clear-eventlog",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/clear-item.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/clear-item",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/clear-itemproperty.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/clear-itemproperty",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/clear-recyclebin.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/clear-recyclebin",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/complete-transaction.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/complete-transaction",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/convert-path.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/convert-path",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/copy-item.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/copy-item",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/copy-itemproperty.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/copy-itemproperty",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/debug-process.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/debug-process",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/disable-computerrestore.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/disable-computerrestore",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/enable-computerrestore.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/enable-computerrestore",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-childitem.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-childitem",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-clipboard.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-clipboard",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-computerinfo.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-computerinfo",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-computerrestorepoint.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-computerrestorepoint",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-content.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-content",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-controlpanelitem.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-controlpanelitem",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-eventlog.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-eventlog",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-hotfix.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-hotfix",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-item.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-item",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-itemproperty.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-itemproperty",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-itempropertyvalue.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-itempropertyvalue",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-location.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-location",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-process.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-process",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-psdrive.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-psdrive",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-psprovider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-psprovider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-service.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-service",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-timezone.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-timezone",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-transaction.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-transaction",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-wmiobject.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-wmiobject",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/invoke-item.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/invoke-item",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/invoke-wmimethod.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/invoke-wmimethod",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/join-path.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/join-path",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/limit-eventlog.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/limit-eventlog",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/microsoft.powershell.management.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/move-item.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/move-item",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/move-itemproperty.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/move-itemproperty",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/new-eventlog.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/new-eventlog",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/new-item.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/new-item",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/new-itemproperty.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/new-itemproperty",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/new-psdrive.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/new-psdrive",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/new-service.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/new-service",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/new-webserviceproxy.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/new-webserviceproxy",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/pop-location.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/pop-location",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/push-location.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/push-location",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/register-wmievent.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/register-wmievent",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/remove-computer.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/remove-computer",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/remove-eventlog.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/remove-eventlog",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/remove-item.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/remove-item",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/remove-itemproperty.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/remove-itemproperty",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/remove-psdrive.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/remove-psdrive",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/remove-wmiobject.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/remove-wmiobject",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/rename-computer.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/rename-computer",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/rename-item.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/rename-item",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/rename-itemproperty.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/rename-itemproperty",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/reset-computermachinepassword.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/reset-computermachinepassword",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/resolve-path.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/resolve-path",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/restart-computer.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/restart-computer",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/restart-service.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/restart-service",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/restore-computer.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/restore-computer",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/resume-service.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/resume-service",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/set-clipboard.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/set-clipboard",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/set-content.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/set-content",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/set-item.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/set-item",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/set-itemproperty.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/set-itemproperty",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/set-location.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/set-location",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/set-service.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/set-service",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/set-timezone.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/set-timezone",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/set-wmiinstance.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/set-wmiinstance",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/show-controlpanelitem.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/show-controlpanelitem",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/show-eventlog.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/show-eventlog",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/split-path.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/split-path",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/start-process.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/start-process",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/start-service.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/start-service",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/start-transaction.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/start-transaction",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/stop-computer.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/stop-computer",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/stop-process.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/stop-process",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/stop-service.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/stop-service",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/suspend-service.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/suspend-service",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/test-computersecurechannel.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/test-computersecurechannel",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/test-connection.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/test-connection",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/test-path.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/test-path",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/undo-transaction.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/undo-transaction",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/use-transaction.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/use-transaction",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/wait-process.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/wait-process",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/write-eventlog.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/write-eventlog",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.odatautils.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.odatautils/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.odatautils/export-odataendpointproxy.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.odatautils/export-odataendpointproxy",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.odatautils/microsoft.powershell.odatautils.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.odatautils/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.operation.validation.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.operation.validation/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.operation.validation/get-operationvalidation.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.operation.validation/get-operationvalidation",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.operation.validation/invoke-operationvalidation.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.operation.validation/invoke-operationvalidation",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.operation.validation/microsoft.powershell.operation.validation.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.operation.validation/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/certificate-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/about/about_certificate_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/convertfrom-securestring.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/convertfrom-securestring",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/convertto-securestring.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/convertto-securestring",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/get-acl.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/get-acl",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/get-authenticodesignature.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/get-authenticodesignature",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/get-cmsmessage.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/get-cmsmessage",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/get-credential.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/get-credential",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/get-executionpolicy.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/get-executionpolicy",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/get-pfxcertificate.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/get-pfxcertificate",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/microsoft.powershell.security.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/new-filecatalog.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/new-filecatalog",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/protect-cmsmessage.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/protect-cmsmessage",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/set-acl.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/set-acl",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/set-authenticodesignature.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/set-authenticodesignature",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/set-executionpolicy.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/set-executionpolicy",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/test-filecatalog.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/test-filecatalog",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/unprotect-cmsmessage.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/unprotect-cmsmessage",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/add-member.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/add-member",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/add-type.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/add-type",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/clear-variable.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/clear-variable",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/compare-object.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/compare-object",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convertfrom-csv.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/convertfrom-csv",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convertfrom-json.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/convertfrom-json",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convertfrom-sddlstring.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/convertfrom-sddlstring",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convertfrom-string.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/convertfrom-string",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convertfrom-stringdata.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/convertfrom-stringdata",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convert-string.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/convert-string",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convertto-csv.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/convertto-csv",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convertto-html.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/convertto-html",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convertto-json.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/convertto-json",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convertto-xml.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/convertto-xml",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/debug-runspace.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/debug-runspace",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/disable-psbreakpoint.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/disable-psbreakpoint",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/disable-runspacedebug.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/disable-runspacedebug",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/enable-psbreakpoint.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/enable-psbreakpoint",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/enable-runspacedebug.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/enable-runspacedebug",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/export-alias.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/export-alias",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/export-clixml.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/export-clixml",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/export-csv.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/export-csv",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/export-formatdata.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/export-formatdata",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/export-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/export-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/format-custom.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/format-custom",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/format-hex.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/format-hex",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/format-list.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/format-list",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/format-table.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/format-table",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/format-wide.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/format-wide",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-alias.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-alias",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-culture.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-culture",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-date.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-date",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-event.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-event",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-eventsubscriber.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-eventsubscriber",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-filehash.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-filehash",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-formatdata.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-formatdata",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-host.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-host",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-member.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-member",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-psbreakpoint.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-psbreakpoint",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-pscallstack.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-pscallstack",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-random.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-random",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-runspace.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-runspace",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-runspacedebug.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-runspacedebug",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-tracesource.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-tracesource",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-typedata.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-typedata",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-uiculture.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-uiculture",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-unique.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-unique",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-variable.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-variable",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/group-object.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/group-object",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/import-alias.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/import-alias",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/import-clixml.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/import-clixml",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/import-csv.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/import-csv",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/import-localizeddata.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/import-localizeddata",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/import-powershelldatafile.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/import-powershelldatafile",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/import-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/import-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/invoke-expression.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/invoke-expression",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/invoke-restmethod.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/invoke-restmethod",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/invoke-webrequest.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/invoke-webrequest",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/measure-command.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/measure-command",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/measure-object.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/measure-object",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/microsoft.powershell.utility.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/new-alias.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/new-alias",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/new-event.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/new-event",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/new-guid.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/new-guid",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/new-object.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/new-object",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/new-temporaryfile.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/new-temporaryfile",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/new-timespan.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/new-timespan",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/new-variable.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/new-variable",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/out-file.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/out-file",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/out-gridview.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/out-gridview",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/out-printer.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/out-printer",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/out-string.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/out-string",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/read-host.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/read-host",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/register-engineevent.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/register-engineevent",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/register-objectevent.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/register-objectevent",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/remove-event.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/remove-event",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/remove-psbreakpoint.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/remove-psbreakpoint",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/remove-typedata.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/remove-typedata",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/remove-variable.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/remove-variable",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/select-object.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/select-object",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/select-string.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/select-string",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/select-xml.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/select-xml",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/send-mailmessage.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/send-mailmessage",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/set-alias.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/set-alias",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/set-date.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/set-date",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/set-psbreakpoint.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/set-psbreakpoint",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/set-tracesource.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/set-tracesource",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/set-variable.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/set-variable",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/show-command.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/show-command",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/sort-object.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/sort-object",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/start-sleep.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/start-sleep",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/tee-object.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/tee-object",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/trace-command.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/trace-command",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/unblock-file.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/unblock-file",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/unregister-event.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/unregister-event",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/update-formatdata.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/update-formatdata",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/update-list.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/update-list",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/update-typedata.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/update-typedata",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/wait-debugger.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/wait-debugger",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/wait-event.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/wait-event",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/write-debug.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/write-debug",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/write-error.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/write-error",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/write-host.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/write-host",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/write-information.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/write-information",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/write-output.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/write-output",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/write-progress.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/write-progress",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/write-verbose.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/write-verbose",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/write-warning.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/write-warning",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/about_ws-management_cmdlets.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/about/about_ws-management_cmdlets",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/connect-wsman.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/connect-wsman",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/disable-wsmancredssp.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/disable-wsmancredssp",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/disconnect-wsman.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/disconnect-wsman",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/enable-wsmancredssp.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/enable-wsmancredssp",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/get-wsmancredssp.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/get-wsmancredssp",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/get-wsmaninstance.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/get-wsmaninstance",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/invoke-wsmanaction.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/invoke-wsmanaction",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/microsoft.wsman.management.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/new-wsmaninstance.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/new-wsmaninstance",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/new-wsmansessionoption.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/new-wsmansessionoption",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/remove-wsmaninstance.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/remove-wsmaninstance",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/set-wsmaninstance.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/set-wsmaninstance",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/set-wsmanquickconfig.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/set-wsmanquickconfig",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/test-wsman.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/test-wsman",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/wsman-provider.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/about/about_wsman_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/packagemanagement.md",
-            "redirect_url": "/powershell/module/packagemanagement/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/packagemanagement/find-package.md",
-            "redirect_url": "/powershell/module/packagemanagement/find-package",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/packagemanagement/find-packageprovider.md",
-            "redirect_url": "/powershell/module/packagemanagement/find-packageprovider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/packagemanagement/get-package.md",
-            "redirect_url": "/powershell/module/packagemanagement/get-package",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/packagemanagement/get-packageprovider.md",
-            "redirect_url": "/powershell/module/packagemanagement/get-packageprovider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/packagemanagement/get-packagesource.md",
-            "redirect_url": "/powershell/module/packagemanagement/get-packagesource",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/packagemanagement/import-packageprovider.md",
-            "redirect_url": "/powershell/module/packagemanagement/import-packageprovider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/packagemanagement/install-package.md",
-            "redirect_url": "/powershell/module/packagemanagement/install-package",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/packagemanagement/install-packageprovider.md",
-            "redirect_url": "/powershell/module/packagemanagement/install-packageprovider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/packagemanagement/packagemanagement.md",
-            "redirect_url": "/powershell/module/packagemanagement/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/packagemanagement/register-packagesource.md",
-            "redirect_url": "/powershell/module/packagemanagement/register-packagesource",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/packagemanagement/save-package.md",
-            "redirect_url": "/powershell/module/packagemanagement/save-package",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/packagemanagement/set-packagesource.md",
-            "redirect_url": "/powershell/module/packagemanagement/set-packagesource",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/packagemanagement/uninstall-package.md",
-            "redirect_url": "/powershell/module/packagemanagement/uninstall-package",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/packagemanagement/unregister-packagesource.md",
-            "redirect_url": "/powershell/module/packagemanagement/unregister-packagesource",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget.md",
-            "redirect_url": "/powershell/module/powershellget/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/find-command.md",
-            "redirect_url": "/powershell/module/powershellget/find-command",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/find-dscresource.md",
-            "redirect_url": "/powershell/module/powershellget/find-dscresource",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/find-module.md",
-            "redirect_url": "/powershell/module/powershellget/find-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/find-rolecapability.md",
-            "redirect_url": "/powershell/module/powershellget/find-rolecapability",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/find-script.md",
-            "redirect_url": "/powershell/module/powershellget/find-script",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/get-installedmodule.md",
-            "redirect_url": "/powershell/module/powershellget/get-installedmodule",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/get-installedscript.md",
-            "redirect_url": "/powershell/module/powershellget/get-installedscript",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/get-psrepository.md",
-            "redirect_url": "/powershell/module/powershellget/get-psrepository",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/install-module.md",
-            "redirect_url": "/powershell/module/powershellget/install-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/install-script.md",
-            "redirect_url": "/powershell/module/powershellget/install-script",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/new-scriptfileinfo.md",
-            "redirect_url": "/powershell/module/powershellget/new-scriptfileinfo",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/powershellget.md",
-            "redirect_url": "/powershell/module/powershellget/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/publish-module.md",
-            "redirect_url": "/powershell/module/powershellget/publish-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/publish-script.md",
-            "redirect_url": "/powershell/module/powershellget/publish-script",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/register-psrepository.md",
-            "redirect_url": "/powershell/module/powershellget/register-psrepository",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/save-module.md",
-            "redirect_url": "/powershell/module/powershellget/save-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/save-script.md",
-            "redirect_url": "/powershell/module/powershellget/save-script",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/set-psrepository.md",
-            "redirect_url": "/powershell/module/powershellget/set-psrepository",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/test-scriptfileinfo.md",
-            "redirect_url": "/powershell/module/powershellget/test-scriptfileinfo",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/uninstall-module.md",
-            "redirect_url": "/powershell/module/powershellget/uninstall-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/uninstall-script.md",
-            "redirect_url": "/powershell/module/powershellget/uninstall-script",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/unregister-psrepository.md",
-            "redirect_url": "/powershell/module/powershellget/unregister-psrepository",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/update-module.md",
-            "redirect_url": "/powershell/module/powershellget/update-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/update-modulemanifest.md",
-            "redirect_url": "/powershell/module/powershellget/update-modulemanifest",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/update-script.md",
-            "redirect_url": "/powershell/module/powershellget/update-script",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/powershellget/update-scriptfileinfo.md",
-            "redirect_url": "/powershell/module/powershellget/update-scriptfileinfo",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/about/about_classes_and_dsc.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/about/about_classes_and_dsc",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/disable-dscdebug.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/disable-dscdebug",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/enable-dscdebug.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/enable-dscdebug",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/get-dscconfiguration.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/get-dscconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/get-dscconfigurationstatus.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/get-dscconfigurationstatus",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/get-dsclocalconfigurationmanager.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/get-dsclocalconfigurationmanager",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/get-dscresource.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/get-dscresource",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/invoke-dscresource.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/invoke-dscresource",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/new-dscchecksum.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/new-dscchecksum",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/psdesiredstateconfiguration.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/publish-dscconfiguration.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/publish-dscconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/remove-dscconfigurationdocument.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/remove-dscconfigurationdocument",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/restore-dscconfiguration.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/restore-dscconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/set-dsclocalconfigurationmanager.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/set-dsclocalconfigurationmanager",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/start-dscconfiguration.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/start-dscconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/stop-dscconfiguration.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/stop-dscconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/test-dscconfiguration.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/test-dscconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/update-dscconfiguration.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/update-dscconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psreadline.md",
-            "redirect_url": "/powershell/module/psreadline/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psreadline/get-psreadlinekeyhandler.md",
-            "redirect_url": "/powershell/module/psreadline/get-psreadlinekeyhandler",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psreadline/get-psreadlineoption.md",
-            "redirect_url": "/powershell/module/psreadline/get-psreadlineoption",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psreadline/psreadline.md",
-            "redirect_url": "/powershell/module/psreadline/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psreadline/remove-psreadlinekeyhandler.md",
-            "redirect_url": "/powershell/module/psreadline/remove-psreadlinekeyhandler",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psreadline/set-psreadlinekeyhandler.md",
-            "redirect_url": "/powershell/module/psreadline/set-psreadlinekeyhandler",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psreadline/set-psreadlineoption.md",
-            "redirect_url": "/powershell/module/psreadline/set-psreadlineoption",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob.md",
-            "redirect_url": "/powershell/module/psscheduledjob/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/about/about_scheduled_jobs.md",
-            "redirect_url": "/powershell/module/psscheduledjob/about/about_scheduled_jobs",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/about/about_scheduled_jobs_advanced.md",
-            "redirect_url": "/powershell/module/psscheduledjob/about/about_scheduled_jobs_advanced",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/about/about_scheduled_jobs_basics.md",
-            "redirect_url": "/powershell/module/psscheduledjob/about/about_scheduled_jobs_basics",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/about/about_scheduled_jobs_troubleshooting.md",
-            "redirect_url": "/powershell/module/psscheduledjob/about/about_scheduled_jobs_troubleshooting",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/add-jobtrigger.md",
-            "redirect_url": "/powershell/module/psscheduledjob/add-jobtrigger",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/disable-jobtrigger.md",
-            "redirect_url": "/powershell/module/psscheduledjob/disable-jobtrigger",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/disable-scheduledjob.md",
-            "redirect_url": "/powershell/module/psscheduledjob/disable-scheduledjob",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/enable-jobtrigger.md",
-            "redirect_url": "/powershell/module/psscheduledjob/enable-jobtrigger",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/enable-scheduledjob.md",
-            "redirect_url": "/powershell/module/psscheduledjob/enable-scheduledjob",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/get-jobtrigger.md",
-            "redirect_url": "/powershell/module/psscheduledjob/get-jobtrigger",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/get-scheduledjob.md",
-            "redirect_url": "/powershell/module/psscheduledjob/get-scheduledjob",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/get-scheduledjoboption.md",
-            "redirect_url": "/powershell/module/psscheduledjob/get-scheduledjoboption",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/new-jobtrigger.md",
-            "redirect_url": "/powershell/module/psscheduledjob/new-jobtrigger",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/new-scheduledjoboption.md",
-            "redirect_url": "/powershell/module/psscheduledjob/new-scheduledjoboption",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/psscheduledjob.md",
-            "redirect_url": "/powershell/module/psscheduledjob/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/register-scheduledjob.md",
-            "redirect_url": "/powershell/module/psscheduledjob/register-scheduledjob",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/remove-jobtrigger.md",
-            "redirect_url": "/powershell/module/psscheduledjob/remove-jobtrigger",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/set-jobtrigger.md",
-            "redirect_url": "/powershell/module/psscheduledjob/set-jobtrigger",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/set-scheduledjob.md",
-            "redirect_url": "/powershell/module/psscheduledjob/set-scheduledjob",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/set-scheduledjoboption.md",
-            "redirect_url": "/powershell/module/psscheduledjob/set-scheduledjoboption",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/unregister-scheduledjob.md",
-            "redirect_url": "/powershell/module/psscheduledjob/unregister-scheduledjob",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psworkflow.md",
-            "redirect_url": "/powershell/module/psworkflow/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psworkflow/about/about_activitycommonparameters.md",
-            "redirect_url": "/powershell/module/psworkflow/about/about_activitycommonparameters",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psworkflow/about/about_checkpoint-workflow.md",
-            "redirect_url": "/powershell/module/psworkflow/about/about_checkpoint-workflow",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psworkflow/about/about_foreach-parallel.md",
-            "redirect_url": "/powershell/module/psworkflow/about/about_foreach-parallel",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psworkflow/about/about_inlinescript.md",
-            "redirect_url": "/powershell/module/psworkflow/about/about_inlinescript",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psworkflow/about/about_parallel.md",
-            "redirect_url": "/powershell/module/psworkflow/about/about_parallel",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psworkflow/about/about_sequence.md",
-            "redirect_url": "/powershell/module/psworkflow/about/about_sequence",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psworkflow/about/about_suspend-workflow.md",
-            "redirect_url": "/powershell/module/psworkflow/about/about_suspend-workflow",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psworkflow/about/about_workflowcommonparameters.md",
-            "redirect_url": "/powershell/module/psworkflow/about/about_workflowcommonparameters",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psworkflow/about/about_workflows.md",
-            "redirect_url": "/powershell/module/psworkflow/about/about_workflows",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psworkflow/new-psworkflowexecutionoption.md",
-            "redirect_url": "/powershell/module/psworkflow/new-psworkflowexecutionoption",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psworkflow/new-psworkflowsession.md",
-            "redirect_url": "/powershell/module/psworkflow/new-psworkflowsession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psworkflow/psworkflow.md",
-            "redirect_url": "/powershell/module/psworkflow/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psworkflowutility.md",
-            "redirect_url": "/powershell/module/psworkflowutility/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psworkflowutility/invoke-asworkflow.md",
-            "redirect_url": "/powershell/module/psworkflowutility/invoke-asworkflow",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/psworkflowutility/psworkflowutility.md",
-            "redirect_url": "/powershell/module/psworkflowutility/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_aliases.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_aliases",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_arithmetic_operators.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_arithmetic_operators",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_arrays.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_arrays",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_assignment_operators.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_assignment_operators",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_automatic_variables.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_automatic_variables",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_break.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_break",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_classes.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_classes",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_command_precedence.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_command_precedence",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_command_syntax.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_command_syntax",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_comment_based_help.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_comment_based_help",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_commonparameters.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_commonparameters",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_comparison_operators.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_comparison_operators",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_continue.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_continue",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_core_commands.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_core_commands",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_data_sections.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_data_sections",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_debuggers.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_debuggers",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_do.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_do",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_enum.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_enum",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_environment_variables.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_environment_variables",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_escape_characters.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_special_characters",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_eventlogs.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_eventlogs",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_execution_policies.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_execution_policies",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_for.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_for",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_foreach.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_foreach",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_format.ps1xml.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_format.ps1xml",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_functions.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_functions_advanced.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_advanced",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_functions_advanced_methods.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_advanced_methods",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_functions_advanced_parameters.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_functions_cmdletbindingattribute.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_cmdletbindingattribute",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_functions_outputtypeattribute.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_outputtypeattribute",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_group_policy_settings.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_group_policy_settings",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_hash_tables.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_hash_tables",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_history.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_history",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_if.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_if",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_job_details.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_job_details",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_jobs.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_jobs",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_join.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_join",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_language_keywords.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_language_keywords",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_language_modes.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_language_modes",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_line_editing.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_line_editing",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_methods.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_methods",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_modules.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_modules",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_object_creation.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_object_creation",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_objects.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_objects",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_operator_precedence.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_operator_precedence",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_operators.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_operators",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_packagemanagement.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_packagemanagement",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_parameters.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_parameters",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_parameters_default_values.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_parameters_default_values",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_parsing.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_parsing",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_path_syntax.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_path_syntax",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_pipelines.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pipelines",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_powershell_exe.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pwsh",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_pwsh.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pwsh",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/7.0/microsoft.powershell.core/about/about_powershell_exe.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pwsh",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/7.1/microsoft.powershell.core/about/about_powershell_exe.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pwsh",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_preference_variables.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_preference_variables",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_profiles.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_profiles",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_prompts.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_prompts",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_properties.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_properties",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_providers.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_providers",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_pssession_details.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pssession_details",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_pssessions.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pssessions",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_pssnapins.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pssnapins",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_quoting_rules.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_quoting_rules",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_redirection.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_redirection",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_ref.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_ref",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_regular_expressions.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_regular_expressions",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_remote.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_remote_disconnected_sessions.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_disconnected_sessions",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_remote_faq.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_faq",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_remote_jobs.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_jobs",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_remote_output.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_output",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_remote_requirements.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_requirements",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_remote_troubleshooting.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_troubleshooting",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_remote_variables.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_variables",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_requires.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_requires",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_reserved_words.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_reserved_words",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_return.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_return",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_run_with_powershell.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_run_with_powershell",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_scopes.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_scopes",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_script_blocks.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_script_blocks",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_script_internationalization.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_script_internationalization",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_scripts.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_scripts",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_session_configuration_files.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_session_configuration_files",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_session_configurations.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_session_configurations",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_signing.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_signing",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_special_characters.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_special_characters",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_splatting.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_splatting",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_split.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_split",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_switch.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_switch",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_throw.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_throw",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_transactions.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_transactions",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_trap.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_trap",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_try_catch_finally.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_try_catch_finally",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_type_operators.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_type_operators",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_types.ps1xml.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_types.ps1xml",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_updatable_help.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_updatable_help",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_variables.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_variables",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_while.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_while",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_wildcards.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_wildcards",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_windows_powershell_ise.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_windows_powershell_ise",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_windows_rt.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_windows_rt",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_wmi.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_wmi",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_wmi_cmdlets.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_wmi_cmdlets",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_wql.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_wql",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_ws-management_cmdlets.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_ws-management_cmdlets",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/cimcmdlets.md",
-            "redirect_url": "/powershell/module/cimcmdlets/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/cimcmdlets/cimcmdlets.md",
-            "redirect_url": "/powershell/module/cimcmdlets/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/cimcmdlets/export-binarymilog.md",
-            "redirect_url": "/powershell/module/cimcmdlets/export-binarymilog",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/cimcmdlets/get-cimassociatedinstance.md",
-            "redirect_url": "/powershell/module/cimcmdlets/get-cimassociatedinstance",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/cimcmdlets/get-cimclass.md",
-            "redirect_url": "/powershell/module/cimcmdlets/get-cimclass",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/cimcmdlets/get-ciminstance.md",
-            "redirect_url": "/powershell/module/cimcmdlets/get-ciminstance",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/cimcmdlets/get-cimsession.md",
-            "redirect_url": "/powershell/module/cimcmdlets/get-cimsession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/cimcmdlets/import-binarymilog.md",
-            "redirect_url": "/powershell/module/cimcmdlets/import-binarymilog",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/cimcmdlets/invoke-cimmethod.md",
-            "redirect_url": "/powershell/module/cimcmdlets/invoke-cimmethod",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/cimcmdlets/new-ciminstance.md",
-            "redirect_url": "/powershell/module/cimcmdlets/new-ciminstance",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/cimcmdlets/new-cimsession.md",
-            "redirect_url": "/powershell/module/cimcmdlets/new-cimsession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/cimcmdlets/new-cimsessionoption.md",
-            "redirect_url": "/powershell/module/cimcmdlets/new-cimsessionoption",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/cimcmdlets/register-cimindicationevent.md",
-            "redirect_url": "/powershell/module/cimcmdlets/register-cimindicationevent",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/cimcmdlets/remove-ciminstance.md",
-            "redirect_url": "/powershell/module/cimcmdlets/remove-ciminstance",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/cimcmdlets/remove-cimsession.md",
-            "redirect_url": "/powershell/module/cimcmdlets/remove-cimsession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/cimcmdlets/set-ciminstance.md",
-            "redirect_url": "/powershell/module/cimcmdlets/set-ciminstance",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/index.md",
-            "redirect_url": "/powershell/module/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.archive.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.archive/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.archive/compress-archive.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.archive/compress-archive",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.archive/expand-archive.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.archive/expand-archive",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.archive/microsoft.powershell.archive.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.archive/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/add-history.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/add-history",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/alias-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_alias_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/clear-history.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/clear-history",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/connect-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/connect-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/debug-job.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/debug-job",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/disable-pssessionconfiguration.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/disable-pssessionconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/disconnect-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/disconnect-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/enable-pssessionconfiguration.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/enable-pssessionconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/enter-pshostprocess.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/enter-pshostprocess",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/enter-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/enter-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/environment-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_environment_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/exit-pshostprocess.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/exit-pshostprocess",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/exit-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/exit-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/export-modulemember.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/export-modulemember",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/filesystem-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_filesystem_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/foreach-object.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/foreach-object",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/function-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_function_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/clear-host.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/clear-host",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/get-command.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-command",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/get-help.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-help",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/get-history.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-history",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/get-job.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-job",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/get-module.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/get-pshostprocessinfo.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-pshostprocessinfo",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/get-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/get-pssessioncapability.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-pssessioncapability",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/get-pssessionconfiguration.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/get-pssessionconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/import-module.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/import-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/invoke-command.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/invoke-command",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/invoke-history.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/invoke-history",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/microsoft.powershell.core.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/new-module.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/new-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/new-modulemanifest.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/new-modulemanifest",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/new-psrolecapabilityfile.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/new-psrolecapabilityfile",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/new-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/new-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/new-pssessionconfigurationfile.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/new-pssessionconfigurationfile",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/new-pssessionoption.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/new-pssessionoption",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/new-pstransportoption.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/new-pstransportoption",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/out-default.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/out-default",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/out-host.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/out-host",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/out-null.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/out-null",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/receive-job.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/receive-job",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/receive-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/receive-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/register-argumentcompleter.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/register-argumentcompleter",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/register-pssessionconfiguration.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/register-pssessionconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/registry-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_registry_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/remove-job.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/remove-job",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/remove-module.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/remove-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/remove-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/remove-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/save-help.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/save-help",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/set-psdebug.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/set-psdebug",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/set-pssessionconfiguration.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/set-pssessionconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/set-strictmode.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/set-strictmode",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/start-job.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/start-job",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/stop-job.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/stop-job",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/test-modulemanifest.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/test-modulemanifest",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/test-pssessionconfigurationfile.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/test-pssessionconfigurationfile",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/unregister-pssessionconfiguration.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/unregister-pssessionconfiguration",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/update-help.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/update-help",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/variable-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_variable_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/wait-job.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/wait-job",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/where-object.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/where-object",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.diagnostics.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.diagnostics/export-counter.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/export-counter",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.diagnostics/get-counter.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/get-counter",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.diagnostics/get-winevent.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/get-winevent",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.diagnostics/import-counter.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/import-counter",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.diagnostics/microsoft.powershell.diagnostics.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.diagnostics/new-winevent.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/new-winevent",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.host.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.host/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.host/microsoft.powershell.host.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.host/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.host/start-transcript.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.host/start-transcript",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.host/stop-transcript.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.host/stop-transcript",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/add-localgroupmember.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/add-localgroupmember",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/disable-localuser.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/disable-localuser",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/enable-localuser.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/enable-localuser",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/get-localgroup.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/get-localgroup",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/get-localgroupmember.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/get-localgroupmember",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/get-localuser.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/get-localuser",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/microsoft.powershell.localaccounts.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/new-localgroup.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/new-localgroup",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/new-localuser.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/new-localuser",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/remove-localgroup.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/remove-localgroup",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/remove-localgroupmember.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/remove-localgroupmember",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/remove-localuser.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/remove-localuser",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/rename-localgroup.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/rename-localgroup",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/rename-localuser.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/rename-localuser",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/set-localgroup.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/set-localgroup",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/set-localuser.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/set-localuser",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/add-content.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/add-content",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/clear-content.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/clear-content",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/clear-item.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/clear-item",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/clear-itemproperty.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/clear-itemproperty",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/convert-path.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/convert-path",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/copy-item.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/copy-item",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/copy-itemproperty.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/copy-itemproperty",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/debug-process.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/debug-process",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-childitem.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-childitem",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-computerinfo.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-computerinfo",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-content.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-content",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-item.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-item",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-itemproperty.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-itemproperty",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-itempropertyvalue.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-itempropertyvalue",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-location.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-location",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-process.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-process",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-psdrive.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-psdrive",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-psprovider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-psprovider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-service.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-service",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-timezone.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/get-timezone",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/invoke-item.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/invoke-item",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/join-path.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/join-path",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/microsoft.powershell.management.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/move-item.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/move-item",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/move-itemproperty.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/move-itemproperty",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/new-item.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/new-item",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/new-itemproperty.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/new-itemproperty",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/new-psdrive.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/new-psdrive",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/new-service.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/new-service",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/pop-location.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/pop-location",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/push-location.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/push-location",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/remove-item.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/remove-item",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/remove-itemproperty.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/remove-itemproperty",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/remove-psdrive.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/remove-psdrive",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/rename-computer.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/rename-computer",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/rename-item.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/rename-item",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/rename-itemproperty.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/rename-itemproperty",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/resolve-path.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/resolve-path",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/restart-computer.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/restart-computer",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/restart-service.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/restart-service",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/resume-service.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/resume-service",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/set-content.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/set-content",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/set-item.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/set-item",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/set-itemproperty.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/set-itemproperty",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/set-location.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/set-location",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/set-service.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/set-service",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/set-timezone.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/set-timezone",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/split-path.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/split-path",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/start-process.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/start-process",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/start-service.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/start-service",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/stop-computer.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/stop-computer",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/stop-process.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/stop-process",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/stop-service.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/stop-service",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/suspend-service.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/suspend-service",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/test-connection.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/test-connection",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/test-path.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/test-path",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/wait-process.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.management/wait-process",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/certificate-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/about/about_certificate_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/convertfrom-securestring.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/convertfrom-securestring",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/convertto-securestring.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/convertto-securestring",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/get-acl.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/get-acl",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/get-authenticodesignature.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/get-authenticodesignature",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/get-credential.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/get-credential",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/get-executionpolicy.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/get-executionpolicy",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/microsoft.powershell.security.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/new-filecatalog.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/new-filecatalog",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/set-acl.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/set-acl",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/set-authenticodesignature.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/set-authenticodesignature",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/set-executionpolicy.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/set-executionpolicy",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/test-filecatalog.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/test-filecatalog",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/add-member.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/add-member",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/add-type.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/add-type",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/clear-variable.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/clear-variable",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/compare-object.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/compare-object",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/convertfrom-csv.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/convertfrom-csv",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/convertfrom-json.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/convertfrom-json",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/convertfrom-sddlstring.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/convertfrom-sddlstring",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/convertfrom-stringdata.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/convertfrom-stringdata",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/convertto-csv.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/convertto-csv",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/convertto-html.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/convertto-html",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/convertto-json.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/convertto-json",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/convertto-xml.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/convertto-xml",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/debug-runspace.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/debug-runspace",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/disable-psbreakpoint.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/disable-psbreakpoint",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/disable-runspacedebug.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/disable-runspacedebug",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/enable-psbreakpoint.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/enable-psbreakpoint",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/enable-runspacedebug.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/enable-runspacedebug",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/export-alias.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/export-alias",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/export-clixml.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/export-clixml",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/export-csv.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/export-csv",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/export-formatdata.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/export-formatdata",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/export-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/export-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/format-custom.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/format-custom",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/format-hex.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/format-hex",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/format-list.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/format-list",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/format-table.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/format-table",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/format-wide.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/format-wide",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-alias.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-alias",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-culture.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-culture",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-date.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-date",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-event.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-event",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-eventsubscriber.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-eventsubscriber",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-filehash.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-filehash",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-formatdata.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-formatdata",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-host.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-host",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-member.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-member",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-psbreakpoint.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-psbreakpoint",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-pscallstack.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-pscallstack",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-random.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-random",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-runspace.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-runspace",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-runspacedebug.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-runspacedebug",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-tracesource.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-tracesource",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-typedata.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-typedata",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-uiculture.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-uiculture",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-unique.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-unique",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-variable.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-variable",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-verb.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/get-verb",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/group-object.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/group-object",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/import-alias.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/import-alias",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/import-clixml.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/import-clixml",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/import-csv.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/import-csv",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/import-localizeddata.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/import-localizeddata",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/import-powershelldatafile.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/import-powershelldatafile",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/import-pssession.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/import-pssession",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/invoke-expression.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/invoke-expression",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/invoke-restmethod.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/invoke-restmethod",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/invoke-webrequest.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/invoke-webrequest",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/measure-command.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/measure-command",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/measure-object.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/measure-object",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/microsoft.powershell.utility.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/new-alias.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/new-alias",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/new-event.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/new-event",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/new-guid.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/new-guid",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/new-object.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/new-object",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/new-temporaryfile.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/new-temporaryfile",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/new-timespan.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/new-timespan",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/new-variable.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/new-variable",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/out-file.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/out-file",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/out-string.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/out-string",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/read-host.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/read-host",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/register-engineevent.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/register-engineevent",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/register-objectevent.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/register-objectevent",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/remove-event.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/remove-event",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/remove-psbreakpoint.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/remove-psbreakpoint",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/remove-typedata.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/remove-typedata",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/remove-variable.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/remove-variable",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/select-object.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/select-object",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/select-string.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/select-string",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/select-xml.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/select-xml",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/set-alias.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/set-alias",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/set-date.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/set-date",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/set-psbreakpoint.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/set-psbreakpoint",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/set-tracesource.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/set-tracesource",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/set-variable.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/set-variable",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/sort-object.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/sort-object",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/start-sleep.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/start-sleep",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/tee-object.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/tee-object",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/trace-command.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/trace-command",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/unblock-file.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/unblock-file",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/unregister-event.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/unregister-event",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/update-formatdata.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/update-formatdata",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/update-typedata.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/update-typedata",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/wait-debugger.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/wait-debugger",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/wait-event.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/wait-event",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/write-debug.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/write-debug",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/write-error.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/write-error",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/write-host.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/write-host",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/write-information.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/write-information",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/write-output.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/write-output",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/write-progress.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/write-progress",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/write-verbose.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/write-verbose",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/write-warning.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.utility/write-warning",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/connect-wsman.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/connect-wsman",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/disable-wsmancredssp.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/disable-wsmancredssp",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/disconnect-wsman.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/disconnect-wsman",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/enable-wsmancredssp.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/enable-wsmancredssp",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/get-wsmancredssp.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/get-wsmancredssp",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/get-wsmaninstance.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/get-wsmaninstance",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/invoke-wsmanaction.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/invoke-wsmanaction",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/microsoft.wsman.management.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/new-wsmaninstance.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/new-wsmaninstance",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/new-wsmansessionoption.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/new-wsmansessionoption",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/remove-wsmaninstance.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/remove-wsmaninstance",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/set-wsmaninstance.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/set-wsmaninstance",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/set-wsmanquickconfig.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/set-wsmanquickconfig",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/test-wsman.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/test-wsman",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/wsman-provider.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/about/about_wsman_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/packagemanagement.md",
-            "redirect_url": "/powershell/module/packagemanagement/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/packagemanagement/find-package.md",
-            "redirect_url": "/powershell/module/packagemanagement/find-package",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/packagemanagement/find-packageprovider.md",
-            "redirect_url": "/powershell/module/packagemanagement/find-packageprovider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/packagemanagement/get-package.md",
-            "redirect_url": "/powershell/module/packagemanagement/get-package",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/packagemanagement/get-packageprovider.md",
-            "redirect_url": "/powershell/module/packagemanagement/get-packageprovider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/packagemanagement/get-packagesource.md",
-            "redirect_url": "/powershell/module/packagemanagement/get-packagesource",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/packagemanagement/import-packageprovider.md",
-            "redirect_url": "/powershell/module/packagemanagement/import-packageprovider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/packagemanagement/install-package.md",
-            "redirect_url": "/powershell/module/packagemanagement/install-package",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/packagemanagement/install-packageprovider.md",
-            "redirect_url": "/powershell/module/packagemanagement/install-packageprovider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/packagemanagement/packagemanagement.md",
-            "redirect_url": "/powershell/module/packagemanagement/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/packagemanagement/register-packagesource.md",
-            "redirect_url": "/powershell/module/packagemanagement/register-packagesource",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/packagemanagement/save-package.md",
-            "redirect_url": "/powershell/module/packagemanagement/save-package",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/packagemanagement/set-packagesource.md",
-            "redirect_url": "/powershell/module/packagemanagement/set-packagesource",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/packagemanagement/uninstall-package.md",
-            "redirect_url": "/powershell/module/packagemanagement/uninstall-package",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/packagemanagement/unregister-packagesource.md",
-            "redirect_url": "/powershell/module/packagemanagement/unregister-packagesource",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget.md",
-            "redirect_url": "/powershell/module/powershellget/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/find-command.md",
-            "redirect_url": "/powershell/module/powershellget/find-command",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/find-dscresource.md",
-            "redirect_url": "/powershell/module/powershellget/find-dscresource",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/find-module.md",
-            "redirect_url": "/powershell/module/powershellget/find-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/find-rolecapability.md",
-            "redirect_url": "/powershell/module/powershellget/find-rolecapability",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/find-script.md",
-            "redirect_url": "/powershell/module/powershellget/find-script",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/get-installedmodule.md",
-            "redirect_url": "/powershell/module/powershellget/get-installedmodule",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/get-installedscript.md",
-            "redirect_url": "/powershell/module/powershellget/get-installedscript",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/get-psrepository.md",
-            "redirect_url": "/powershell/module/powershellget/get-psrepository",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/install-module.md",
-            "redirect_url": "/powershell/module/powershellget/install-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/install-script.md",
-            "redirect_url": "/powershell/module/powershellget/install-script",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/new-scriptfileinfo.md",
-            "redirect_url": "/powershell/module/powershellget/new-scriptfileinfo",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/powershellget.md",
-            "redirect_url": "/powershell/module/powershellget/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/publish-module.md",
-            "redirect_url": "/powershell/module/powershellget/publish-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/publish-script.md",
-            "redirect_url": "/powershell/module/powershellget/publish-script",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/register-psrepository.md",
-            "redirect_url": "/powershell/module/powershellget/register-psrepository",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/save-module.md",
-            "redirect_url": "/powershell/module/powershellget/save-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/save-script.md",
-            "redirect_url": "/powershell/module/powershellget/save-script",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/set-psrepository.md",
-            "redirect_url": "/powershell/module/powershellget/set-psrepository",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/test-scriptfileinfo.md",
-            "redirect_url": "/powershell/module/powershellget/test-scriptfileinfo",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/uninstall-module.md",
-            "redirect_url": "/powershell/module/powershellget/uninstall-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/uninstall-script.md",
-            "redirect_url": "/powershell/module/powershellget/uninstall-script",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/unregister-psrepository.md",
-            "redirect_url": "/powershell/module/powershellget/unregister-psrepository",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/update-module.md",
-            "redirect_url": "/powershell/module/powershellget/update-module",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/update-modulemanifest.md",
-            "redirect_url": "/powershell/module/powershellget/update-modulemanifest",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/update-script.md",
-            "redirect_url": "/powershell/module/powershellget/update-script",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/powershellget/update-scriptfileinfo.md",
-            "redirect_url": "/powershell/module/powershellget/update-scriptfileinfo",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psdesiredstateconfiguration.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psdesiredstateconfiguration/about/about_classes_and_dsc.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/about/about_classes_and_dsc",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psdesiredstateconfiguration/get-dscresource.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/get-dscresource",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psdesiredstateconfiguration/new-dscchecksum.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/new-dscchecksum",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psdesiredstateconfiguration/psdesiredstateconfiguration.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psdiagnostics/disable-pstrace.md",
-            "redirect_url": "/powershell/module/psdiagnostics/disable-pstrace",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psdiagnostics/disable-pswsmancombinedtrace.md",
-            "redirect_url": "/powershell/module/psdiagnostics/disable-pswsmancombinedtrace",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psdiagnostics/disable-wsmantrace.md",
-            "redirect_url": "/powershell/module/psdiagnostics/disable-wsmantrace",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psdiagnostics/enable-pstrace.md",
-            "redirect_url": "/powershell/module/psdiagnostics/enable-pstrace",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psdiagnostics/enable-pswsmancombinedtrace.md",
-            "redirect_url": "/powershell/module/psdiagnostics/enable-pswsmancombinedtrace",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psdiagnostics/enable-wsmantrace.md",
-            "redirect_url": "/powershell/module/psdiagnostics/enable-wsmantrace",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psdiagnostics/get-logproperties.md",
-            "redirect_url": "/powershell/module/psdiagnostics/get-logproperties",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psdiagnostics/psdiagnostics.md",
-            "redirect_url": "/powershell/module/psdiagnostics/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psdiagnostics/set-logproperties.md",
-            "redirect_url": "/powershell/module/psdiagnostics/set-logproperties",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psdiagnostics/start-trace.md",
-            "redirect_url": "/powershell/module/psdiagnostics/start-trace",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psdiagnostics/stop-trace.md",
-            "redirect_url": "/powershell/module/psdiagnostics/stop-trace",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psreadline.md",
-            "redirect_url": "/powershell/module/psreadline/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psreadline/get-psreadlinekeyhandler.md",
-            "redirect_url": "/powershell/module/psreadline/get-psreadlinekeyhandler",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psreadline/get-psreadlineoption.md",
-            "redirect_url": "/powershell/module/psreadline/get-psreadlineoption",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psreadline/psconsolehostreadline.md",
-            "redirect_url": "/powershell/module/psreadline/psconsolehostreadline",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psreadline/psreadline.md",
-            "redirect_url": "/powershell/module/psreadline/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psreadline/remove-psreadlinekeyhandler.md",
-            "redirect_url": "/powershell/module/psreadline/remove-psreadlinekeyhandler",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psreadline/set-psreadlinekeyhandler.md",
-            "redirect_url": "/powershell/module/psreadline/set-psreadlinekeyhandler",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/psreadline/set-psreadlineoption.md",
-            "redirect_url": "/powershell/module/psreadline/set-psreadlineoption",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/6/readme.md",
-            "redirect_url": "/powershell/scripting/overview",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/microsoft.powershell.core/about.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/microsoft.powershell.core/alias-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_alias_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/microsoft.powershell.core/environment-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_environment_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/microsoft.powershell.core/filesystem-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_filesystem_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/microsoft.powershell.core/function-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_function_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/microsoft.powershell.core/providers/alias-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_alias_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/microsoft.powershell.core/providers/environment-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_environment_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/microsoft.powershell.core/providers/filesystem-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_filesystem_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/microsoft.powershell.core/providers/function-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_function_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/microsoft.powershell.core/providers/registry-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_registry_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/microsoft.powershell.core/providers/variable-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_variable_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/microsoft.powershell.core/registry-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_registry_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/microsoft.powershell.core/variable-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_variable_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/microsoft.powershell.security/certificate-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/about/about_certificate_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/microsoft.powershell.security/providers/certificate-provider.md",
-            "redirect_url": "/powershell/module/microsoft.powershell.security/about/about_certificate_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/microsoft.wsman.management/about_ws-management_cmdlets.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/about/about_ws-management_cmdlets",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/microsoft.wsman.management/providers/wsman-provider.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/about/about_wsman_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/microsoft.wsman.management/wsman-provider.md",
-            "redirect_url": "/powershell/module/microsoft.wsman.management/about/about_wsman_provider",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/psdesiredstateconfiguration/about_classes_and_dsc.md",
-            "redirect_url": "/powershell/module/psdesiredstateconfiguration/about/about_classes_and_dsc",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/psscheduledjob/about_scheduled_jobs.md",
-            "redirect_url": "/powershell/module/psscheduledjob/about/about_scheduled_jobs",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/psscheduledjob/about_scheduled_jobs_advanced.md",
-            "redirect_url": "/powershell/module/psscheduledjob/about/about_scheduled_jobs_advanced",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/psscheduledjob/about_scheduled_jobs_basics.md",
-            "redirect_url": "/powershell/module/psscheduledjob/about/about_scheduled_jobs_basics",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/psscheduledjob/about_scheduled_jobs_troubleshooting.md",
-            "redirect_url": "/powershell/module/psscheduledjob/about/about_scheduled_jobs_troubleshooting",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/psworkflow/about_activitycommonparameters.md",
-            "redirect_url": "/powershell/module/psworkflow/about/about_activitycommonparameters",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/psworkflow/about_checkpoint-workflow.md",
-            "redirect_url": "/powershell/module/psworkflow/about/about_checkpoint-workflow",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/psworkflow/about_foreach-parallel.md",
-            "redirect_url": "/powershell/module/psworkflow/about/about_foreach-parallel",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/psworkflow/about_inlinescript.md",
-            "redirect_url": "/powershell/module/psworkflow/about/about_inlinescript",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/psworkflow/about_parallel.md",
-            "redirect_url": "/powershell/module/psworkflow/about/about_parallel",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/psworkflow/about_sequence.md",
-            "redirect_url": "/powershell/module/psworkflow/about/about_sequence",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/psworkflow/about_suspend-workflow.md",
-            "redirect_url": "/powershell/module/psworkflow/about/about_suspend-workflow",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/psworkflow/about_workflowcommonparameters.md",
-            "redirect_url": "/powershell/module/psworkflow/about/about_workflowcommonparameters",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/psworkflow/about_workflows.md",
-            "redirect_url": "/powershell/module/psworkflow/about/about_workflows",
-            "redirect_document_id": false
-        },
-        {
-            "source_path": "reference/virtual-directory-module/readme.md",
-            "redirect_url": "/powershell/scripting/overview",
-            "redirect_document_id": false
-        }
-    ]
+  "redirections": [
+    {
+      "source_path": "reference/docs-conceptual/dsc/tutorials/dscCiCd.md",
+      "redirect_url": "/azure/devops/pipelines/get-started/dsc-cicd",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/index.md",
+      "redirect_url": "/powershell/scripting/overview",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "digital-art.md",
+      "redirect_url": "/powershell/scripting/community/digital-art",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/digital-art.md",
+      "redirect_url": "/powershell/scripting/community/digital-art",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/community/whats-new-in-docs.md",
+      "redirect_url": "/powershell/scripting/community/community-update",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/index.md",
+      "redirect_url": "/powershell/scripting/developer/windows-powershell",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/dsc/index.md",
+      "redirect_url": "/powershell/scripting/dsc/overview/decisionmaker",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/gallery/index.md",
+      "redirect_url": "/powershell/scripting/gallery/overview",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/index.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/overview",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/dsc/getting-started/azuredscexthistory.md",
+      "redirect_url": "/azure/automation/automation-dsc-extension-history",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/dsc/getting-started/azuredsc.md",
+      "redirect_url": "/azure/automation/automation-dsc-getting-started",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/whats-new/experimental-features.md",
+      "redirect_url": "/powershell/scripting/learn/experimental-features",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/learn/ps101/Getting-Detailed-Help-Information.md",
+      "redirect_url": "/powershell/scripting/learn/ps101/02-help-system",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/learn/ps101/Getting-Information-About-Commands.md",
+      "redirect_url": "/powershell/scripting/learn/ps101/02-help-system",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/learn/ps101/Learning-PowerShell-Names.md",
+      "redirect_url": "/powershell/scripting/learn/ps101/02-help-system",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/learn/ps101/PowerShell.exe-Command-Line-Help.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_powershell_exe",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/learn/ps101/Using-Familiar-Command-Names.md",
+      "redirect_url": "/powershell/scripting/learn/ps101/05-formatting-aliases-providers-comparison",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/learn/ps101/Using-Variables-to-Store-Objects.md",
+      "redirect_url": "/powershell/scripting/learn/ps101/03-discovering-objects",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/learn/ps101/Using-Tab-Expansion.md",
+      "redirect_url": "/powershell/scripting/learn/Using-Tab-Expansion",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/console/using-tab-expansion.md",
+      "redirect_url": "/powershell/scripting/learn/ps101/using-tab-expansion",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/learn/getting-detailed-help-information.md",
+      "redirect_url": "/powershell/scripting/learn/ps101/02-help-system",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/learn/getting-information-about-commands.md",
+      "redirect_url": "/powershell/scripting/learn/ps101/02-help-system",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/learn/learning-powershell-names.md",
+      "redirect_url": "/powershell/scripting/learn/ps101/02-help-system",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/learn/using-familiar-command-names.md",
+      "redirect_url": "/powershell/scripting/learn/ps101/05-formatting-aliases-providers-comparison",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/learn/using-variables-to-store-objects.md",
+      "redirect_url": "/powershell/scripting/learn/ps101/03-discovering-objects",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/whats-new/migrating-from-windows-powershell-51-to-powershell-7.md",
+      "redirect_url": "/powershell/scripting/install/migrating-from-windows-powershell-51-to-powershell-7",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/whats-new/what-s-new-in-the-powershell-50-ise.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/whats-new/what-s-new-in-the-powershell-50-ise",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/whats-new/what-s-new-in-windows-powershell-50.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/whats-new/what-s-new-in-windows-powershell-50",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/cmdlet/writing-a-windows-powershell-cmdlet.md",
+      "redirect_url": "/powershell/scripting/developer/cmdlet/cmdlet-overview",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/format/examples-of-formatting-files.md",
+      "redirect_url": "/powershell/scripting/developer/format/wide-view-basic",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/format/writing-a-powershell-formatting-file.md",
+      "redirect_url": "/powershell/scripting/developer/format/formatting-file-overview",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/hosting/writing-a-windows-powershell-host-application.md",
+      "redirect_url": "/powershell/scripting/developer/hosting/windows-powershell-host-quickstart",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/provider/writing-a-windows-powershell-provider.md",
+      "redirect_url": "/powershell/scripting/developer/provider/windows-powershell-provider-quickstart",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/getting-started/getting-started-with-windows-powershell.md",
+      "redirect_url": "/powershell/scripting/overview",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/install/installing-windows-powershell.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/install/installing-windows-powershell",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/learn/understanding-important-powershell-concepts.md",
+      "redirect_url": "/powershell/scripting/overview",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/learn/understanding-the-powershell-pipeline.md",
+      "redirect_url": "/powershell/scripting/overview",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/install/windows-powershell-system-requirements.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/install/windows-powershell-system-requirements",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/accessibility-in-windows-powershell-ise.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/accessibility-in-windows-powershell-ise",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/exploring-the-windows-powershell-ise.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/exploring-the-windows-powershell-ise",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/how-to-create-a-powershell-tab-in-windows-powershell-ise.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/how-to-create-a-powershell-tab-in-windows-powershell-ise",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/how-to-debug-scripts-in-windows-powershell-ise.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/how-to-debug-scripts-in-windows-powershell-ise",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/how-to-use-profiles-in-windows-powershell-ise.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/how-to-use-profiles-in-windows-powershell-ise",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/how-to-use-tab-completion-in-the-script-pane-and-console-pane.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/how-to-use-tab-completion-in-the-script-pane-and-console-pane",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/how-to-use-the-console-pane-in-the-windows-powershell-ise.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/how-to-use-the-console-pane-in-the-windows-powershell-ise",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/how-to-write-and-run-scripts-in-the-windows-powershell-ise.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/how-to-write-and-run-scripts-in-the-windows-powershell-ise",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/introducing-the-windows-powershell-ise.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/introducing-the-windows-powershell-ise",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/keyboard-shortcuts-for-the-windows-powershell-ise.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/keyboard-shortcuts-for-the-windows-powershell-ise",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/object-model/purpose-of-the-windows-powershell-ise-scripting-object-model.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/purpose-of-the-windows-powershell-ise-scripting-object-model",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/object-model/the-iseaddontoolcollection-object.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-iseaddontoolcollection-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/object-model/the-iseaddontool-object.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-iseaddontool-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/object-model/the-iseeditor-object.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-iseeditor-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/object-model/the-isefilecollection-object.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-isefilecollection-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/object-model/the-isefile-object.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-isefile-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/object-model/the-isemenuitemcollection-object.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-isemenuitemcollection-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/object-model/the-isemenuitem-object.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-isemenuitem-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/object-model/the-ise-object-model-hierarchy.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-ise-object-model-hierarchy",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/object-model/the-iseoptions-object.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-iseoptions-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/object-model/the-isesnippetcollection-object.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-isesnippetcollection-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/object-model/the-isesnippetobject.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-isesnippetobject",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/object-model/the-objectmodelroot-object.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-objectmodelroot-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/object-model/the-powershelltabcollection-object.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-powershelltabcollection-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/ise/object-model/the-powershelltab-object.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/ise/object-model/the-powershelltab-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/vscode/how-to-replicate-the-ise-experience-in-vscode.md",
+      "redirect_url": "/powershell/scripting/dev-cross-plat/vscode/how-to-replicate-the-ise-experience-in-vscode",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/vscode/understanding-file-encoding.md",
+      "redirect_url": "/powershell/scripting/dev-cross-plat/vscode/understanding-file-encoding",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/vscode/using-vscode.md",
+      "redirect_url": "/powershell/scripting/dev-cross-plat/vscode/using-vscode",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/components/vscode/using-vscode-for-remote-editing-and-debugging.md",
+      "redirect_url": "/powershell/scripting/dev-cross-plat/vscode/using-vscode-for-remote-editing-and-debugging",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/cmdlet/how-to-create-a-windows-powershell-snap-in.md",
+      "redirect_url": "/powershell/scripting/developer/module/how-to-create-a-windows-powershell-snap-in",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/cmdlet/how-to-import-cmdlets-using-modules.md",
+      "redirect_url": "/powershell/scripting/developer/module/how-to-import-cmdlets-using-modules",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/cmdlet/modules-and-snap-ins.md",
+      "redirect_url": "/powershell/scripting/developer/module/modules-and-snap-ins",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/cmdlet/registering-cmdlets.md",
+      "redirect_url": "/powershell/scripting/developer/module/registering-cmdlets",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/cmdlet/writing-a-custom-windows-powershell-snap-in.md",
+      "redirect_url": "/powershell/scripting/developer/module/writing-a-custom-windows-powershell-snap-in",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/cmdlet/writing-a-windows-powershell-snap-in.md",
+      "redirect_url": "/powershell/scripting/developer/module/writing-a-windows-powershell-snap-in",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/module/file-types-permitted-in-an-updatable-help-cab-file.md",
+      "redirect_url": "/powershell/scripting/developer/help/file-types-permitted-in-an-updatable-help-cab-file",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/module/helpinfo-xml-sample-file.md",
+      "redirect_url": "/powershell/scripting/developer/help/helpinfo-xml-sample-file",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/module/helpinfo-xml-schema.md",
+      "redirect_url": "/powershell/scripting/developer/help/helpinfo-xml-schema",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/module/how-to-create-a-helpinfo-xml-file.md",
+      "redirect_url": "/powershell/scripting/developer/help/how-to-create-a-helpinfo-xml-file",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/module/how-to-create-and-upload-cab-files.md",
+      "redirect_url": "/powershell/scripting/developer/help/how-to-create-and-upload-cab-files",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/module/how-to-name-a-helpinfo-xml-file.md",
+      "redirect_url": "/powershell/scripting/developer/help/how-to-name-a-helpinfo-xml-file",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/module/how-to-name-an-updatable-help-cab-file.md",
+      "redirect_url": "/powershell/scripting/developer/help/how-to-name-an-updatable-help-cab-file",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/module/how-to-prepare-updatable-help-cab-files.md",
+      "redirect_url": "/powershell/scripting/developer/help/how-to-prepare-updatable-help-cab-files",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/module/how-to-set-helpinfo-xml-version-numbers.md",
+      "redirect_url": "/powershell/scripting/developer/help/how-to-set-helpinfo-xml-version-numbers",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/module/how-to-test-updatable-help.md",
+      "redirect_url": "/powershell/scripting/developer/help/how-to-test-updatable-help",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/module/how-to-update-help-files.md",
+      "redirect_url": "/powershell/scripting/developer/help/how-to-update-help-files",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/module/how-updatable-help-works.md",
+      "redirect_url": "/powershell/scripting/developer/help/how-updatable-help-works",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/module/naming-help-files.md",
+      "redirect_url": "/powershell/scripting/developer/help/naming-help-files",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/module/supporting-online-help.md",
+      "redirect_url": "/powershell/scripting/developer/help/supporting-online-help",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/module/supporting-updatable-help.md",
+      "redirect_url": "/powershell/scripting/developer/help/supporting-updatable-help",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/module/updatable-help-authoring-step-by-step.md",
+      "redirect_url": "/powershell/scripting/developer/help/updatable-help-authoring-step-by-step",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/module/updatable-help-overview.md",
+      "redirect_url": "/powershell/scripting/developer/help/updatable-help-overview",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/developer/module/writing-help-for-windows-powershell-modules.md",
+      "redirect_url": "/powershell/scripting/developer/help/writing-help-for-windows-powershell-modules",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/getting-started/starting-the-windows-powershell-2.0-engine.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/starting-the-windows-powershell-2.0-engine",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/getting-started/starting-windows-powershell.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/starting-windows-powershell",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/install/installing-the-windows-powershell-2.0-engine.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/install/installing-the-windows-powershell-2.0-engine",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/learn/windows-powershell-glossary.md",
+      "redirect_url": "/powershell/scripting/learn/glossary",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/learn/writing-portable-modules.md",
+      "redirect_url": "/powershell/scripting/dev-cross-plat/writing-portable-modules",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/known-issues/known-issues-50.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/known-issues/known-issues-50",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/known-issues/known-issues-51.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/known-issues/known-issues-51",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/known-issues/known-issues-dsc.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/known-issues/known-issues-dsc",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/overview.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/overview",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/setup/install-configure.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/setup/install-configure",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/setup/uninstall.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/setup/uninstall",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/whats-new/bugfixes.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/bugfixes",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/whats-new/class-overview.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/class-overview",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/whats-new/compatibility.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/compatibility",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/whats-new/console-improvements.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/console-improvements",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/whats-new/debug-overview.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/debug-overview",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/whats-new/dsc-improvements.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/dsc-improvements",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/whats-new/engine-improvements.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/engine-improvements",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/whats-new/informationstream-overview.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/informationstream-overview",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/whats-new/jea-improvements.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/jea-improvements",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/whats-new/new-updated-cmdlets.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/new-updated-cmdlets",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/whats-new/package-management-improvements.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/package-management-improvements",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/whats-new/release-notes.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/release-notes",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/whats-new/script-logging.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/script-logging",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/docs-conceptual/wmf/whats-new/sil-overview.md",
+      "redirect_url": "/powershell/scripting/windows-powershell/wmf/whats-new/sil-overview",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/ise.md",
+      "redirect_url": "/powershell/module/ise/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/ise/get-isesnippet.md",
+      "redirect_url": "/powershell/module/ise/get-isesnippet",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/ise/import-isesnippet.md",
+      "redirect_url": "/powershell/module/ise/import-isesnippet",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/ise/ise.md",
+      "redirect_url": "/powershell/module/ise/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/ise/new-isesnippet.md",
+      "redirect_url": "/powershell/module/ise/new-isesnippet",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.archive.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.archive/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.archive/compress-archive.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.archive/compress-archive",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.archive/expand-archive.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.archive/expand-archive",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.archive/microsoft.powershell.archive.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.archive/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_aliases.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_aliases",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_arithmetic_operators.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_arithmetic_operators",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_arrays.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_arrays",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_assignment_operators.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_assignment_operators",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_automatic_variables.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_automatic_variables",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_break.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_break",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_classes.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_classes",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_command_precedence.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_command_precedence",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_command_syntax.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_command_syntax",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_comment_based_help.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_comment_based_help",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_commonparameters.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_commonparameters",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_comparison_operators.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_comparison_operators",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_continue.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_continue",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_core_commands.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_core_commands",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_data_sections.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_data_sections",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_debuggers.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_debuggers",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_desiredstateconfiguration.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_desiredstateconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_do.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_do",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_dsclogresource.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_dsclogresource",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_enum.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_enum",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_environment_variables.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_environment_variables",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_escape_characters.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_special_characters",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_eventlogs.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_eventlogs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_execution_policies.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_execution_policies",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_for.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_for",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_foreach.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_foreach",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_format.ps1xml.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_format.ps1xml",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_functions.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_functions_advanced.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_advanced",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_functions_advanced_methods.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_advanced_methods",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_functions_advanced_parameters.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_functions_cmdletbindingattribute.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_cmdletbindingattribute",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_functions_outputtypeattribute.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_outputtypeattribute",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_group_policy_settings.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_group_policy_settings",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_hash_tables.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_hash_tables",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_hidden.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_hidden",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_history.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_history",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_if.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_if",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_job_details.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_job_details",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_jobs.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_jobs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_join.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_join",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_language_keywords.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_language_keywords",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_language_modes.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_language_modes",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_line_editing.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_line_editing",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_locations.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_locations",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_logical_operators.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_logical_operators",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_methods.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_methods",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_modules.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_modules",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_object_creation.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_object_creation",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_objects.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_objects",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_operator_precedence.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_operator_precedence",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_operators.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_operators",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_packagemanagement.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_packagemanagement",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_parameters.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_parameters",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_parameters_default_values.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_parameters_default_values",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_parsing.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_parsing",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_path_syntax.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_path_syntax",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_pipelines.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pipelines",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_powershell_exe.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_powershell_exe",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_powershell_ise_exe.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_powershell_ise_exe",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_preference_variables.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_preference_variables",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_profiles.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_profiles",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_prompts.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_prompts",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_properties.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_properties",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_providers.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_providers",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_psconsolehostreadline.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_psconsolehostreadline",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_psreadline.md",
+      "redirect_url": "/powershell/module/psreadline/about/about_psreadline",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_pssession_details.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pssession_details",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_pssessions.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pssessions",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_pssnapins.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pssnapins",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_quoting_rules.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_quoting_rules",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_redirection.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_redirection",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_ref.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_ref",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_regular_expressions.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_regular_expressions",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_remote.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_remote_disconnected_sessions.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_disconnected_sessions",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_remote_faq.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_faq",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_remote_jobs.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_jobs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_remote_output.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_output",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_remote_requirements.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_requirements",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_remote_troubleshooting.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_troubleshooting",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_remote_variables.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_variables",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_requires.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_requires",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_reserved_words.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_reserved_words",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_return.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_return",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_run_with_powershell.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_run_with_powershell",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_scopes.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_scopes",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_script_blocks.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_script_blocks",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_script_internationalization.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_script_internationalization",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_scripts.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_scripts",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_session_configuration_files.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_session_configuration_files",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_session_configurations.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_session_configurations",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_signing.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_signing",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_simplified_syntax.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_simplified_syntax",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_special_characters.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_special_characters",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_splatting.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_splatting",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_split.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_split",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_switch.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_switch",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_throw.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_throw",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_transactions.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_transactions",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_trap.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_trap",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_try_catch_finally.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_try_catch_finally",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_type_accelerators.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_type_accelerators",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_type_operators.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_type_operators",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_types.ps1xml.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_types.ps1xml",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_updatable_help.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_updatable_help",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_variables.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_variables",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_while.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_while",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_wildcards.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_wildcards",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_windows_powershell_5.1.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_windows_powershell_5.1",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_windows_powershell_ise.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_windows_powershell_ise",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_windows_rt.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_windows_rt",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_wmi.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_wmi",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_wmi_cmdlets.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_wmi_cmdlets",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_wql.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_wql",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/add-history.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/add-history",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/add-pssnapin.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/add-pssnapin",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/alias-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_alias_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/clear-history.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/clear-history",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/connect-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/connect-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/debug-job.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/debug-job",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/disable-psremoting.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/disable-psremoting",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/disable-pssessionconfiguration.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/disable-pssessionconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/disconnect-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/disconnect-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/enable-psremoting.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/enable-psremoting",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/enable-pssessionconfiguration.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/enable-pssessionconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/enter-pshostprocess.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/enter-pshostprocess",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/enter-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/enter-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/environment-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_environment_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/exit-pshostprocess.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/exit-pshostprocess",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/exit-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/exit-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/export-console.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/export-console",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/export-modulemember.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/export-modulemember",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/filesystem-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_filesystem_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/foreach-object.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/foreach-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/function-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_function_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/functions/clear-host.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/clear-host",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/clear-host.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/clear-host",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/functions/get-verb.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-verb",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-verb.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-verb",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-command.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-command",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-help.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-help",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-history.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-history",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-job.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-job",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-module.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-pshostprocessinfo.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-pshostprocessinfo",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-pssessioncapability.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-pssessioncapability",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-pssessionconfiguration.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-pssessionconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/get-pssnapin.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-pssnapin",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/import-module.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/import-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/invoke-command.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/invoke-command",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/invoke-history.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/invoke-history",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/microsoft.powershell.core.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/new-module.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/new-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/new-modulemanifest.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/new-modulemanifest",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/new-psrolecapabilityfile.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/new-psrolecapabilityfile",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/new-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/new-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/new-pssessionconfigurationfile.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/new-pssessionconfigurationfile",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/new-pssessionoption.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/new-pssessionoption",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/new-pstransportoption.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/new-pstransportoption",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/out-default.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/out-default",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/out-host.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/out-host",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/out-null.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/out-null",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/receive-job.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/receive-job",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/receive-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/receive-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/register-argumentcompleter.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/register-argumentcompleter",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/register-pssessionconfiguration.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/register-pssessionconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/registry-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_registry_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/remove-job.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/remove-job",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/remove-module.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/remove-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/remove-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/remove-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/remove-pssnapin.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/remove-pssnapin",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/resume-job.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/resume-job",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/save-help.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/save-help",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/set-psdebug.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/set-psdebug",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/set-pssessionconfiguration.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/set-pssessionconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/set-strictmode.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/set-strictmode",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/start-job.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/start-job",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/stop-job.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/stop-job",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/suspend-job.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/suspend-job",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/test-modulemanifest.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/test-modulemanifest",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/test-pssessionconfigurationfile.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/test-pssessionconfigurationfile",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/unregister-pssessionconfiguration.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/unregister-pssessionconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/update-help.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/update-help",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/variable-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_variable_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/wait-job.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/wait-job",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/where-object.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/where-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.diagnostics.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.diagnostics/export-counter.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/export-counter",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.diagnostics/get-counter.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/get-counter",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.diagnostics/get-winevent.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/get-winevent",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.diagnostics/import-counter.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/import-counter",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.diagnostics/microsoft.powershell.diagnostics.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.diagnostics/new-winevent.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/new-winevent",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.host.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.host/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.host/microsoft.powershell.host.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.host/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.host/start-transcript.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.host/start-transcript",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.host/stop-transcript.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.host/stop-transcript",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/add-localgroupmember.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/add-localgroupmember",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/disable-localuser.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/disable-localuser",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/enable-localuser.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/enable-localuser",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/get-localgroup.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/get-localgroup",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/get-localgroupmember.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/get-localgroupmember",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/get-localuser.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/get-localuser",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/microsoft.powershell.localaccounts.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/new-localgroup.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/new-localgroup",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/new-localuser.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/new-localuser",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/remove-localgroup.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/remove-localgroup",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/remove-localgroupmember.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/remove-localgroupmember",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/remove-localuser.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/remove-localuser",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/rename-localgroup.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/rename-localgroup",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/rename-localuser.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/rename-localuser",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/set-localgroup.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/set-localgroup",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.localaccounts/set-localuser.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/set-localuser",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/add-computer.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/add-computer",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/add-content.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/add-content",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/checkpoint-computer.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/checkpoint-computer",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/clear-content.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/clear-content",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/clear-eventlog.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/clear-eventlog",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/clear-item.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/clear-item",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/clear-itemproperty.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/clear-itemproperty",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/clear-recyclebin.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/clear-recyclebin",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/complete-transaction.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/complete-transaction",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/convert-path.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/convert-path",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/copy-item.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/copy-item",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/copy-itemproperty.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/copy-itemproperty",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/debug-process.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/debug-process",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/disable-computerrestore.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/disable-computerrestore",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/enable-computerrestore.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/enable-computerrestore",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-childitem.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-childitem",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-clipboard.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-clipboard",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-computerinfo.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-computerinfo",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-computerrestorepoint.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-computerrestorepoint",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-content.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-content",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-controlpanelitem.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-controlpanelitem",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-eventlog.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-eventlog",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-hotfix.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-hotfix",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-item.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-item",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-itemproperty.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-itemproperty",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-itempropertyvalue.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-itempropertyvalue",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-location.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-location",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-process.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-process",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-psdrive.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-psdrive",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-psprovider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-psprovider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-service.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-service",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-timezone.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-timezone",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-transaction.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-transaction",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/get-wmiobject.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-wmiobject",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/invoke-item.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/invoke-item",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/invoke-wmimethod.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/invoke-wmimethod",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/join-path.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/join-path",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/limit-eventlog.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/limit-eventlog",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/microsoft.powershell.management.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/move-item.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/move-item",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/move-itemproperty.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/move-itemproperty",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/new-eventlog.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/new-eventlog",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/new-item.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/new-item",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/new-itemproperty.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/new-itemproperty",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/new-psdrive.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/new-psdrive",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/new-service.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/new-service",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/new-webserviceproxy.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/new-webserviceproxy",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/pop-location.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/pop-location",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/push-location.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/push-location",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/register-wmievent.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/register-wmievent",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/remove-computer.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/remove-computer",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/remove-eventlog.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/remove-eventlog",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/remove-item.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/remove-item",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/remove-itemproperty.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/remove-itemproperty",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/remove-psdrive.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/remove-psdrive",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/remove-wmiobject.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/remove-wmiobject",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/rename-computer.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/rename-computer",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/rename-item.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/rename-item",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/rename-itemproperty.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/rename-itemproperty",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/reset-computermachinepassword.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/reset-computermachinepassword",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/resolve-path.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/resolve-path",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/restart-computer.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/restart-computer",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/restart-service.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/restart-service",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/restore-computer.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/restore-computer",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/resume-service.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/resume-service",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/set-clipboard.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/set-clipboard",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/set-content.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/set-content",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/set-item.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/set-item",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/set-itemproperty.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/set-itemproperty",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/set-location.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/set-location",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/set-service.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/set-service",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/set-timezone.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/set-timezone",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/set-wmiinstance.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/set-wmiinstance",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/show-controlpanelitem.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/show-controlpanelitem",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/show-eventlog.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/show-eventlog",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/split-path.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/split-path",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/start-process.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/start-process",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/start-service.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/start-service",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/start-transaction.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/start-transaction",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/stop-computer.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/stop-computer",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/stop-process.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/stop-process",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/stop-service.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/stop-service",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/suspend-service.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/suspend-service",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/test-computersecurechannel.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/test-computersecurechannel",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/test-connection.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/test-connection",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/test-path.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/test-path",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/undo-transaction.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/undo-transaction",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/use-transaction.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/use-transaction",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/wait-process.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/wait-process",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.management/write-eventlog.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/write-eventlog",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.odatautils.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.odatautils/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.odatautils/export-odataendpointproxy.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.odatautils/export-odataendpointproxy",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.odatautils/microsoft.powershell.odatautils.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.odatautils/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.operation.validation.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.operation.validation/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.operation.validation/get-operationvalidation.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.operation.validation/get-operationvalidation",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.operation.validation/invoke-operationvalidation.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.operation.validation/invoke-operationvalidation",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.operation.validation/microsoft.powershell.operation.validation.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.operation.validation/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/certificate-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/about/about_certificate_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/convertfrom-securestring.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/convertfrom-securestring",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/convertto-securestring.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/convertto-securestring",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/get-acl.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/get-acl",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/get-authenticodesignature.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/get-authenticodesignature",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/get-cmsmessage.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/get-cmsmessage",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/get-credential.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/get-credential",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/get-executionpolicy.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/get-executionpolicy",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/get-pfxcertificate.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/get-pfxcertificate",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/microsoft.powershell.security.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/new-filecatalog.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/new-filecatalog",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/protect-cmsmessage.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/protect-cmsmessage",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/set-acl.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/set-acl",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/set-authenticodesignature.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/set-authenticodesignature",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/set-executionpolicy.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/set-executionpolicy",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/test-filecatalog.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/test-filecatalog",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.security/unprotect-cmsmessage.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/unprotect-cmsmessage",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/add-member.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/add-member",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/add-type.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/add-type",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/clear-variable.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/clear-variable",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/compare-object.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/compare-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convertfrom-csv.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/convertfrom-csv",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convertfrom-json.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/convertfrom-json",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convertfrom-sddlstring.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/convertfrom-sddlstring",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convertfrom-string.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/convertfrom-string",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convertfrom-stringdata.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/convertfrom-stringdata",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convert-string.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/convert-string",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convertto-csv.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/convertto-csv",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convertto-html.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/convertto-html",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convertto-json.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/convertto-json",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/convertto-xml.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/convertto-xml",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/debug-runspace.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/debug-runspace",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/disable-psbreakpoint.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/disable-psbreakpoint",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/disable-runspacedebug.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/disable-runspacedebug",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/enable-psbreakpoint.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/enable-psbreakpoint",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/enable-runspacedebug.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/enable-runspacedebug",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/export-alias.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/export-alias",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/export-clixml.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/export-clixml",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/export-csv.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/export-csv",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/export-formatdata.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/export-formatdata",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/export-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/export-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/format-custom.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/format-custom",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/format-hex.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/format-hex",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/format-list.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/format-list",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/format-table.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/format-table",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/format-wide.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/format-wide",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-alias.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-alias",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-culture.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-culture",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-date.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-date",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-event.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-event",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-eventsubscriber.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-eventsubscriber",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-filehash.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-filehash",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-formatdata.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-formatdata",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-host.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-host",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-member.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-member",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-psbreakpoint.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-psbreakpoint",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-pscallstack.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-pscallstack",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-random.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-random",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-runspace.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-runspace",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-runspacedebug.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-runspacedebug",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-tracesource.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-tracesource",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-typedata.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-typedata",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-uiculture.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-uiculture",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-unique.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-unique",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/get-variable.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-variable",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/group-object.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/group-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/import-alias.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/import-alias",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/import-clixml.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/import-clixml",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/import-csv.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/import-csv",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/import-localizeddata.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/import-localizeddata",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/import-powershelldatafile.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/import-powershelldatafile",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/import-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/import-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/invoke-expression.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/invoke-expression",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/invoke-restmethod.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/invoke-restmethod",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/invoke-webrequest.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/invoke-webrequest",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/measure-command.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/measure-command",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/measure-object.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/measure-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/microsoft.powershell.utility.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/new-alias.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/new-alias",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/new-event.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/new-event",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/new-guid.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/new-guid",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/new-object.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/new-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/new-temporaryfile.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/new-temporaryfile",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/new-timespan.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/new-timespan",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/new-variable.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/new-variable",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/out-file.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/out-file",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/out-gridview.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/out-gridview",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/out-printer.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/out-printer",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/out-string.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/out-string",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/read-host.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/read-host",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/register-engineevent.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/register-engineevent",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/register-objectevent.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/register-objectevent",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/remove-event.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/remove-event",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/remove-psbreakpoint.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/remove-psbreakpoint",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/remove-typedata.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/remove-typedata",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/remove-variable.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/remove-variable",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/select-object.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/select-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/select-string.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/select-string",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/select-xml.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/select-xml",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/send-mailmessage.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/send-mailmessage",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/set-alias.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/set-alias",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/set-date.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/set-date",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/set-psbreakpoint.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/set-psbreakpoint",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/set-tracesource.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/set-tracesource",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/set-variable.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/set-variable",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/show-command.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/show-command",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/sort-object.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/sort-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/start-sleep.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/start-sleep",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/tee-object.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/tee-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/trace-command.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/trace-command",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/unblock-file.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/unblock-file",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/unregister-event.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/unregister-event",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/update-formatdata.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/update-formatdata",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/update-list.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/update-list",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/update-typedata.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/update-typedata",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/wait-debugger.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/wait-debugger",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/wait-event.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/wait-event",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/write-debug.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/write-debug",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/write-error.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/write-error",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/write-host.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/write-host",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/write-information.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/write-information",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/write-output.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/write-output",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/write-progress.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/write-progress",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/write-verbose.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/write-verbose",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.utility/write-warning.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/write-warning",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/about_ws-management_cmdlets.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/about/about_ws-management_cmdlets",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/connect-wsman.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/connect-wsman",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/disable-wsmancredssp.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/disable-wsmancredssp",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/disconnect-wsman.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/disconnect-wsman",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/enable-wsmancredssp.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/enable-wsmancredssp",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/get-wsmancredssp.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/get-wsmancredssp",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/get-wsmaninstance.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/get-wsmaninstance",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/invoke-wsmanaction.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/invoke-wsmanaction",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/microsoft.wsman.management.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/new-wsmaninstance.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/new-wsmaninstance",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/new-wsmansessionoption.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/new-wsmansessionoption",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/remove-wsmaninstance.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/remove-wsmaninstance",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/set-wsmaninstance.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/set-wsmaninstance",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/set-wsmanquickconfig.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/set-wsmanquickconfig",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/test-wsman.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/test-wsman",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.wsman.management/wsman-provider.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/about/about_wsman_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/packagemanagement.md",
+      "redirect_url": "/powershell/module/packagemanagement/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/packagemanagement/find-package.md",
+      "redirect_url": "/powershell/module/packagemanagement/find-package",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/packagemanagement/find-packageprovider.md",
+      "redirect_url": "/powershell/module/packagemanagement/find-packageprovider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/packagemanagement/get-package.md",
+      "redirect_url": "/powershell/module/packagemanagement/get-package",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/packagemanagement/get-packageprovider.md",
+      "redirect_url": "/powershell/module/packagemanagement/get-packageprovider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/packagemanagement/get-packagesource.md",
+      "redirect_url": "/powershell/module/packagemanagement/get-packagesource",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/packagemanagement/import-packageprovider.md",
+      "redirect_url": "/powershell/module/packagemanagement/import-packageprovider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/packagemanagement/install-package.md",
+      "redirect_url": "/powershell/module/packagemanagement/install-package",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/packagemanagement/install-packageprovider.md",
+      "redirect_url": "/powershell/module/packagemanagement/install-packageprovider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/packagemanagement/packagemanagement.md",
+      "redirect_url": "/powershell/module/packagemanagement/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/packagemanagement/register-packagesource.md",
+      "redirect_url": "/powershell/module/packagemanagement/register-packagesource",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/packagemanagement/save-package.md",
+      "redirect_url": "/powershell/module/packagemanagement/save-package",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/packagemanagement/set-packagesource.md",
+      "redirect_url": "/powershell/module/packagemanagement/set-packagesource",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/packagemanagement/uninstall-package.md",
+      "redirect_url": "/powershell/module/packagemanagement/uninstall-package",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/packagemanagement/unregister-packagesource.md",
+      "redirect_url": "/powershell/module/packagemanagement/unregister-packagesource",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget.md",
+      "redirect_url": "/powershell/module/powershellget/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/find-command.md",
+      "redirect_url": "/powershell/module/powershellget/find-command",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/find-dscresource.md",
+      "redirect_url": "/powershell/module/powershellget/find-dscresource",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/find-module.md",
+      "redirect_url": "/powershell/module/powershellget/find-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/find-rolecapability.md",
+      "redirect_url": "/powershell/module/powershellget/find-rolecapability",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/find-script.md",
+      "redirect_url": "/powershell/module/powershellget/find-script",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/get-installedmodule.md",
+      "redirect_url": "/powershell/module/powershellget/get-installedmodule",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/get-installedscript.md",
+      "redirect_url": "/powershell/module/powershellget/get-installedscript",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/get-psrepository.md",
+      "redirect_url": "/powershell/module/powershellget/get-psrepository",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/install-module.md",
+      "redirect_url": "/powershell/module/powershellget/install-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/install-script.md",
+      "redirect_url": "/powershell/module/powershellget/install-script",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/new-scriptfileinfo.md",
+      "redirect_url": "/powershell/module/powershellget/new-scriptfileinfo",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/powershellget.md",
+      "redirect_url": "/powershell/module/powershellget/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/publish-module.md",
+      "redirect_url": "/powershell/module/powershellget/publish-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/publish-script.md",
+      "redirect_url": "/powershell/module/powershellget/publish-script",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/register-psrepository.md",
+      "redirect_url": "/powershell/module/powershellget/register-psrepository",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/save-module.md",
+      "redirect_url": "/powershell/module/powershellget/save-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/save-script.md",
+      "redirect_url": "/powershell/module/powershellget/save-script",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/set-psrepository.md",
+      "redirect_url": "/powershell/module/powershellget/set-psrepository",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/test-scriptfileinfo.md",
+      "redirect_url": "/powershell/module/powershellget/test-scriptfileinfo",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/uninstall-module.md",
+      "redirect_url": "/powershell/module/powershellget/uninstall-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/uninstall-script.md",
+      "redirect_url": "/powershell/module/powershellget/uninstall-script",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/unregister-psrepository.md",
+      "redirect_url": "/powershell/module/powershellget/unregister-psrepository",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/update-module.md",
+      "redirect_url": "/powershell/module/powershellget/update-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/update-modulemanifest.md",
+      "redirect_url": "/powershell/module/powershellget/update-modulemanifest",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/update-script.md",
+      "redirect_url": "/powershell/module/powershellget/update-script",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/powershellget/update-scriptfileinfo.md",
+      "redirect_url": "/powershell/module/powershellget/update-scriptfileinfo",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/about/about_classes_and_dsc.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/about/about_classes_and_dsc",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/disable-dscdebug.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/disable-dscdebug",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/enable-dscdebug.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/enable-dscdebug",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/get-dscconfiguration.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/get-dscconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/get-dscconfigurationstatus.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/get-dscconfigurationstatus",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/get-dsclocalconfigurationmanager.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/get-dsclocalconfigurationmanager",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/get-dscresource.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/get-dscresource",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/invoke-dscresource.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/invoke-dscresource",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/new-dscchecksum.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/new-dscchecksum",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/psdesiredstateconfiguration.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/publish-dscconfiguration.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/publish-dscconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/remove-dscconfigurationdocument.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/remove-dscconfigurationdocument",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/restore-dscconfiguration.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/restore-dscconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/set-dsclocalconfigurationmanager.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/set-dsclocalconfigurationmanager",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/start-dscconfiguration.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/start-dscconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/stop-dscconfiguration.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/stop-dscconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/test-dscconfiguration.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/test-dscconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psdesiredstateconfiguration/update-dscconfiguration.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/update-dscconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psreadline.md",
+      "redirect_url": "/powershell/module/psreadline/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psreadline/get-psreadlinekeyhandler.md",
+      "redirect_url": "/powershell/module/psreadline/get-psreadlinekeyhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psreadline/get-psreadlineoption.md",
+      "redirect_url": "/powershell/module/psreadline/get-psreadlineoption",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psreadline/psreadline.md",
+      "redirect_url": "/powershell/module/psreadline/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psreadline/remove-psreadlinekeyhandler.md",
+      "redirect_url": "/powershell/module/psreadline/remove-psreadlinekeyhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psreadline/set-psreadlinekeyhandler.md",
+      "redirect_url": "/powershell/module/psreadline/set-psreadlinekeyhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psreadline/set-psreadlineoption.md",
+      "redirect_url": "/powershell/module/psreadline/set-psreadlineoption",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob.md",
+      "redirect_url": "/powershell/module/psscheduledjob/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/about/about_scheduled_jobs.md",
+      "redirect_url": "/powershell/module/psscheduledjob/about/about_scheduled_jobs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/about/about_scheduled_jobs_advanced.md",
+      "redirect_url": "/powershell/module/psscheduledjob/about/about_scheduled_jobs_advanced",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/about/about_scheduled_jobs_basics.md",
+      "redirect_url": "/powershell/module/psscheduledjob/about/about_scheduled_jobs_basics",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/about/about_scheduled_jobs_troubleshooting.md",
+      "redirect_url": "/powershell/module/psscheduledjob/about/about_scheduled_jobs_troubleshooting",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/add-jobtrigger.md",
+      "redirect_url": "/powershell/module/psscheduledjob/add-jobtrigger",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/disable-jobtrigger.md",
+      "redirect_url": "/powershell/module/psscheduledjob/disable-jobtrigger",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/disable-scheduledjob.md",
+      "redirect_url": "/powershell/module/psscheduledjob/disable-scheduledjob",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/enable-jobtrigger.md",
+      "redirect_url": "/powershell/module/psscheduledjob/enable-jobtrigger",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/enable-scheduledjob.md",
+      "redirect_url": "/powershell/module/psscheduledjob/enable-scheduledjob",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/get-jobtrigger.md",
+      "redirect_url": "/powershell/module/psscheduledjob/get-jobtrigger",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/get-scheduledjob.md",
+      "redirect_url": "/powershell/module/psscheduledjob/get-scheduledjob",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/get-scheduledjoboption.md",
+      "redirect_url": "/powershell/module/psscheduledjob/get-scheduledjoboption",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/new-jobtrigger.md",
+      "redirect_url": "/powershell/module/psscheduledjob/new-jobtrigger",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/new-scheduledjoboption.md",
+      "redirect_url": "/powershell/module/psscheduledjob/new-scheduledjoboption",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/psscheduledjob.md",
+      "redirect_url": "/powershell/module/psscheduledjob/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/register-scheduledjob.md",
+      "redirect_url": "/powershell/module/psscheduledjob/register-scheduledjob",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/remove-jobtrigger.md",
+      "redirect_url": "/powershell/module/psscheduledjob/remove-jobtrigger",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/set-jobtrigger.md",
+      "redirect_url": "/powershell/module/psscheduledjob/set-jobtrigger",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/set-scheduledjob.md",
+      "redirect_url": "/powershell/module/psscheduledjob/set-scheduledjob",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/set-scheduledjoboption.md",
+      "redirect_url": "/powershell/module/psscheduledjob/set-scheduledjoboption",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psscheduledjob/unregister-scheduledjob.md",
+      "redirect_url": "/powershell/module/psscheduledjob/unregister-scheduledjob",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psworkflow.md",
+      "redirect_url": "/powershell/module/psworkflow/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psworkflow/about/about_activitycommonparameters.md",
+      "redirect_url": "/powershell/module/psworkflow/about/about_activitycommonparameters",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psworkflow/about/about_checkpoint-workflow.md",
+      "redirect_url": "/powershell/module/psworkflow/about/about_checkpoint-workflow",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psworkflow/about/about_foreach-parallel.md",
+      "redirect_url": "/powershell/module/psworkflow/about/about_foreach-parallel",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psworkflow/about/about_inlinescript.md",
+      "redirect_url": "/powershell/module/psworkflow/about/about_inlinescript",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psworkflow/about/about_parallel.md",
+      "redirect_url": "/powershell/module/psworkflow/about/about_parallel",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psworkflow/about/about_sequence.md",
+      "redirect_url": "/powershell/module/psworkflow/about/about_sequence",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psworkflow/about/about_suspend-workflow.md",
+      "redirect_url": "/powershell/module/psworkflow/about/about_suspend-workflow",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psworkflow/about/about_workflowcommonparameters.md",
+      "redirect_url": "/powershell/module/psworkflow/about/about_workflowcommonparameters",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psworkflow/about/about_workflows.md",
+      "redirect_url": "/powershell/module/psworkflow/about/about_workflows",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psworkflow/new-psworkflowexecutionoption.md",
+      "redirect_url": "/powershell/module/psworkflow/new-psworkflowexecutionoption",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psworkflow/new-psworkflowsession.md",
+      "redirect_url": "/powershell/module/psworkflow/new-psworkflowsession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psworkflow/psworkflow.md",
+      "redirect_url": "/powershell/module/psworkflow/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psworkflowutility.md",
+      "redirect_url": "/powershell/module/psworkflowutility/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psworkflowutility/invoke-asworkflow.md",
+      "redirect_url": "/powershell/module/psworkflowutility/invoke-asworkflow",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/psworkflowutility/psworkflowutility.md",
+      "redirect_url": "/powershell/module/psworkflowutility/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_aliases.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_aliases",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_arithmetic_operators.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_arithmetic_operators",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_arrays.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_arrays",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_assignment_operators.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_assignment_operators",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_automatic_variables.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_automatic_variables",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_break.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_break",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_classes.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_classes",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_command_precedence.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_command_precedence",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_command_syntax.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_command_syntax",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_comment_based_help.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_comment_based_help",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_commonparameters.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_commonparameters",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_comparison_operators.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_comparison_operators",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_continue.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_continue",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_core_commands.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_core_commands",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_data_sections.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_data_sections",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_debuggers.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_debuggers",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_do.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_do",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_enum.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_enum",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_environment_variables.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_environment_variables",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_escape_characters.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_special_characters",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_eventlogs.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_eventlogs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_execution_policies.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_execution_policies",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_for.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_for",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_foreach.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_foreach",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_format.ps1xml.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_format.ps1xml",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_functions.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_functions_advanced.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_advanced",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_functions_advanced_methods.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_advanced_methods",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_functions_advanced_parameters.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_functions_cmdletbindingattribute.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_cmdletbindingattribute",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_functions_outputtypeattribute.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_functions_outputtypeattribute",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_group_policy_settings.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_group_policy_settings",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_hash_tables.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_hash_tables",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_history.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_history",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_if.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_if",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_job_details.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_job_details",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_jobs.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_jobs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_join.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_join",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_language_keywords.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_language_keywords",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_language_modes.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_language_modes",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_line_editing.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_line_editing",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_methods.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_methods",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_modules.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_modules",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_object_creation.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_object_creation",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_objects.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_objects",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_operator_precedence.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_operator_precedence",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_operators.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_operators",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_packagemanagement.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_packagemanagement",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_parameters.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_parameters",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_parameters_default_values.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_parameters_default_values",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_parsing.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_parsing",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_path_syntax.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_path_syntax",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_pipelines.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pipelines",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_powershell_exe.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pwsh",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/5.1/microsoft.powershell.core/about/about_pwsh.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pwsh",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/7.0/microsoft.powershell.core/about/about_powershell_exe.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pwsh",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/7.1/microsoft.powershell.core/about/about_powershell_exe.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pwsh",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_preference_variables.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_preference_variables",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_profiles.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_profiles",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_prompts.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_prompts",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_properties.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_properties",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_providers.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_providers",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_pssession_details.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pssession_details",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_pssessions.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pssessions",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_pssnapins.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_pssnapins",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_quoting_rules.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_quoting_rules",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_redirection.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_redirection",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_ref.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_ref",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_regular_expressions.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_regular_expressions",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_remote.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_remote_disconnected_sessions.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_disconnected_sessions",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_remote_faq.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_faq",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_remote_jobs.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_jobs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_remote_output.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_output",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_remote_requirements.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_requirements",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_remote_troubleshooting.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_troubleshooting",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_remote_variables.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_remote_variables",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_requires.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_requires",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_reserved_words.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_reserved_words",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_return.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_return",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_run_with_powershell.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_run_with_powershell",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_scopes.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_scopes",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_script_blocks.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_script_blocks",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_script_internationalization.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_script_internationalization",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_scripts.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_scripts",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_session_configuration_files.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_session_configuration_files",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_session_configurations.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_session_configurations",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_signing.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_signing",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_special_characters.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_special_characters",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_splatting.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_splatting",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_split.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_split",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_switch.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_switch",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_throw.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_throw",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_transactions.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_transactions",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_trap.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_trap",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_try_catch_finally.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_try_catch_finally",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_type_operators.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_type_operators",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_types.ps1xml.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_types.ps1xml",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_updatable_help.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_updatable_help",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_variables.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_variables",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_while.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_while",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_wildcards.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_wildcards",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_windows_powershell_ise.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_windows_powershell_ise",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_windows_rt.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_windows_rt",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_wmi.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_wmi",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_wmi_cmdlets.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_wmi_cmdlets",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_wql.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_wql",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_ws-management_cmdlets.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_ws-management_cmdlets",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/cimcmdlets.md",
+      "redirect_url": "/powershell/module/cimcmdlets/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/cimcmdlets/cimcmdlets.md",
+      "redirect_url": "/powershell/module/cimcmdlets/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/cimcmdlets/export-binarymilog.md",
+      "redirect_url": "/powershell/module/cimcmdlets/export-binarymilog",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/cimcmdlets/get-cimassociatedinstance.md",
+      "redirect_url": "/powershell/module/cimcmdlets/get-cimassociatedinstance",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/cimcmdlets/get-cimclass.md",
+      "redirect_url": "/powershell/module/cimcmdlets/get-cimclass",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/cimcmdlets/get-ciminstance.md",
+      "redirect_url": "/powershell/module/cimcmdlets/get-ciminstance",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/cimcmdlets/get-cimsession.md",
+      "redirect_url": "/powershell/module/cimcmdlets/get-cimsession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/cimcmdlets/import-binarymilog.md",
+      "redirect_url": "/powershell/module/cimcmdlets/import-binarymilog",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/cimcmdlets/invoke-cimmethod.md",
+      "redirect_url": "/powershell/module/cimcmdlets/invoke-cimmethod",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/cimcmdlets/new-ciminstance.md",
+      "redirect_url": "/powershell/module/cimcmdlets/new-ciminstance",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/cimcmdlets/new-cimsession.md",
+      "redirect_url": "/powershell/module/cimcmdlets/new-cimsession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/cimcmdlets/new-cimsessionoption.md",
+      "redirect_url": "/powershell/module/cimcmdlets/new-cimsessionoption",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/cimcmdlets/register-cimindicationevent.md",
+      "redirect_url": "/powershell/module/cimcmdlets/register-cimindicationevent",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/cimcmdlets/remove-ciminstance.md",
+      "redirect_url": "/powershell/module/cimcmdlets/remove-ciminstance",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/cimcmdlets/remove-cimsession.md",
+      "redirect_url": "/powershell/module/cimcmdlets/remove-cimsession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/cimcmdlets/set-ciminstance.md",
+      "redirect_url": "/powershell/module/cimcmdlets/set-ciminstance",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/index.md",
+      "redirect_url": "/powershell/module/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.archive.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.archive/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.archive/compress-archive.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.archive/compress-archive",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.archive/expand-archive.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.archive/expand-archive",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.archive/microsoft.powershell.archive.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.archive/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/add-history.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/add-history",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/alias-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_alias_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/clear-history.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/clear-history",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/connect-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/connect-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/debug-job.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/debug-job",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/disable-pssessionconfiguration.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/disable-pssessionconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/disconnect-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/disconnect-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/enable-pssessionconfiguration.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/enable-pssessionconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/enter-pshostprocess.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/enter-pshostprocess",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/enter-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/enter-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/environment-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_environment_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/exit-pshostprocess.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/exit-pshostprocess",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/exit-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/exit-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/export-modulemember.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/export-modulemember",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/filesystem-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_filesystem_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/foreach-object.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/foreach-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/function-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_function_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/clear-host.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/clear-host",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/get-command.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-command",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/get-help.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-help",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/get-history.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-history",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/get-job.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-job",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/get-module.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/get-pshostprocessinfo.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-pshostprocessinfo",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/get-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/get-pssessioncapability.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-pssessioncapability",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/get-pssessionconfiguration.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/get-pssessionconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/import-module.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/import-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/invoke-command.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/invoke-command",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/invoke-history.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/invoke-history",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/microsoft.powershell.core.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/new-module.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/new-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/new-modulemanifest.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/new-modulemanifest",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/new-psrolecapabilityfile.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/new-psrolecapabilityfile",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/new-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/new-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/new-pssessionconfigurationfile.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/new-pssessionconfigurationfile",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/new-pssessionoption.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/new-pssessionoption",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/new-pstransportoption.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/new-pstransportoption",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/out-default.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/out-default",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/out-host.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/out-host",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/out-null.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/out-null",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/receive-job.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/receive-job",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/receive-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/receive-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/register-argumentcompleter.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/register-argumentcompleter",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/register-pssessionconfiguration.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/register-pssessionconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/registry-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_registry_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/remove-job.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/remove-job",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/remove-module.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/remove-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/remove-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/remove-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/save-help.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/save-help",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/set-psdebug.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/set-psdebug",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/set-pssessionconfiguration.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/set-pssessionconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/set-strictmode.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/set-strictmode",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/start-job.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/start-job",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/stop-job.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/stop-job",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/test-modulemanifest.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/test-modulemanifest",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/test-pssessionconfigurationfile.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/test-pssessionconfigurationfile",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/unregister-pssessionconfiguration.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/unregister-pssessionconfiguration",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/update-help.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/update-help",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/variable-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_variable_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/wait-job.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/wait-job",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/where-object.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/where-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.diagnostics.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.diagnostics/export-counter.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/export-counter",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.diagnostics/get-counter.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/get-counter",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.diagnostics/get-winevent.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/get-winevent",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.diagnostics/import-counter.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/import-counter",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.diagnostics/microsoft.powershell.diagnostics.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.diagnostics/new-winevent.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.diagnostics/new-winevent",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.host.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.host/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.host/microsoft.powershell.host.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.host/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.host/start-transcript.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.host/start-transcript",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.host/stop-transcript.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.host/stop-transcript",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/add-localgroupmember.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/add-localgroupmember",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/disable-localuser.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/disable-localuser",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/enable-localuser.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/enable-localuser",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/get-localgroup.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/get-localgroup",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/get-localgroupmember.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/get-localgroupmember",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/get-localuser.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/get-localuser",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/microsoft.powershell.localaccounts.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/new-localgroup.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/new-localgroup",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/new-localuser.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/new-localuser",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/remove-localgroup.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/remove-localgroup",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/remove-localgroupmember.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/remove-localgroupmember",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/remove-localuser.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/remove-localuser",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/rename-localgroup.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/rename-localgroup",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/rename-localuser.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/rename-localuser",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/set-localgroup.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/set-localgroup",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.localaccounts/set-localuser.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.localaccounts/set-localuser",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/add-content.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/add-content",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/clear-content.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/clear-content",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/clear-item.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/clear-item",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/clear-itemproperty.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/clear-itemproperty",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/convert-path.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/convert-path",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/copy-item.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/copy-item",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/copy-itemproperty.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/copy-itemproperty",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/debug-process.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/debug-process",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-childitem.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-childitem",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-computerinfo.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-computerinfo",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-content.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-content",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-item.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-item",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-itemproperty.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-itemproperty",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-itempropertyvalue.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-itempropertyvalue",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-location.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-location",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-process.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-process",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-psdrive.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-psdrive",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-psprovider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-psprovider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-service.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-service",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/get-timezone.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/get-timezone",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/invoke-item.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/invoke-item",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/join-path.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/join-path",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/microsoft.powershell.management.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/move-item.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/move-item",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/move-itemproperty.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/move-itemproperty",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/new-item.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/new-item",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/new-itemproperty.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/new-itemproperty",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/new-psdrive.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/new-psdrive",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/new-service.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/new-service",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/pop-location.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/pop-location",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/push-location.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/push-location",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/remove-item.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/remove-item",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/remove-itemproperty.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/remove-itemproperty",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/remove-psdrive.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/remove-psdrive",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/rename-computer.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/rename-computer",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/rename-item.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/rename-item",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/rename-itemproperty.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/rename-itemproperty",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/resolve-path.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/resolve-path",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/restart-computer.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/restart-computer",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/restart-service.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/restart-service",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/resume-service.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/resume-service",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/set-content.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/set-content",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/set-item.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/set-item",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/set-itemproperty.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/set-itemproperty",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/set-location.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/set-location",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/set-service.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/set-service",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/set-timezone.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/set-timezone",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/split-path.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/split-path",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/start-process.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/start-process",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/start-service.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/start-service",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/stop-computer.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/stop-computer",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/stop-process.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/stop-process",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/stop-service.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/stop-service",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/suspend-service.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/suspend-service",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/test-connection.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/test-connection",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/test-path.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/test-path",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.management/wait-process.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.management/wait-process",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/certificate-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/about/about_certificate_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/convertfrom-securestring.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/convertfrom-securestring",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/convertto-securestring.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/convertto-securestring",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/get-acl.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/get-acl",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/get-authenticodesignature.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/get-authenticodesignature",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/get-credential.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/get-credential",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/get-executionpolicy.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/get-executionpolicy",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/microsoft.powershell.security.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/new-filecatalog.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/new-filecatalog",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/set-acl.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/set-acl",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/set-authenticodesignature.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/set-authenticodesignature",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/set-executionpolicy.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/set-executionpolicy",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.security/test-filecatalog.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/test-filecatalog",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/add-member.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/add-member",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/add-type.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/add-type",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/clear-variable.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/clear-variable",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/compare-object.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/compare-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/convertfrom-csv.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/convertfrom-csv",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/convertfrom-json.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/convertfrom-json",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/convertfrom-sddlstring.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/convertfrom-sddlstring",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/convertfrom-stringdata.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/convertfrom-stringdata",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/convertto-csv.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/convertto-csv",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/convertto-html.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/convertto-html",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/convertto-json.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/convertto-json",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/convertto-xml.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/convertto-xml",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/debug-runspace.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/debug-runspace",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/disable-psbreakpoint.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/disable-psbreakpoint",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/disable-runspacedebug.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/disable-runspacedebug",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/enable-psbreakpoint.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/enable-psbreakpoint",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/enable-runspacedebug.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/enable-runspacedebug",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/export-alias.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/export-alias",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/export-clixml.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/export-clixml",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/export-csv.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/export-csv",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/export-formatdata.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/export-formatdata",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/export-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/export-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/format-custom.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/format-custom",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/format-hex.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/format-hex",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/format-list.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/format-list",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/format-table.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/format-table",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/format-wide.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/format-wide",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-alias.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-alias",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-culture.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-culture",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-date.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-date",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-event.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-event",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-eventsubscriber.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-eventsubscriber",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-filehash.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-filehash",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-formatdata.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-formatdata",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-host.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-host",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-member.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-member",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-psbreakpoint.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-psbreakpoint",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-pscallstack.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-pscallstack",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-random.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-random",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-runspace.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-runspace",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-runspacedebug.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-runspacedebug",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-tracesource.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-tracesource",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-typedata.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-typedata",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-uiculture.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-uiculture",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-unique.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-unique",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-variable.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-variable",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/get-verb.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/get-verb",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/group-object.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/group-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/import-alias.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/import-alias",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/import-clixml.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/import-clixml",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/import-csv.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/import-csv",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/import-localizeddata.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/import-localizeddata",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/import-powershelldatafile.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/import-powershelldatafile",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/import-pssession.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/import-pssession",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/invoke-expression.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/invoke-expression",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/invoke-restmethod.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/invoke-restmethod",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/invoke-webrequest.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/invoke-webrequest",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/measure-command.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/measure-command",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/measure-object.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/measure-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/microsoft.powershell.utility.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/new-alias.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/new-alias",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/new-event.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/new-event",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/new-guid.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/new-guid",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/new-object.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/new-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/new-temporaryfile.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/new-temporaryfile",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/new-timespan.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/new-timespan",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/new-variable.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/new-variable",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/out-file.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/out-file",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/out-string.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/out-string",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/read-host.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/read-host",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/register-engineevent.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/register-engineevent",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/register-objectevent.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/register-objectevent",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/remove-event.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/remove-event",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/remove-psbreakpoint.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/remove-psbreakpoint",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/remove-typedata.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/remove-typedata",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/remove-variable.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/remove-variable",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/select-object.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/select-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/select-string.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/select-string",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/select-xml.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/select-xml",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/set-alias.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/set-alias",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/set-date.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/set-date",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/set-psbreakpoint.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/set-psbreakpoint",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/set-tracesource.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/set-tracesource",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/set-variable.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/set-variable",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/sort-object.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/sort-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/start-sleep.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/start-sleep",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/tee-object.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/tee-object",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/trace-command.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/trace-command",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/unblock-file.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/unblock-file",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/unregister-event.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/unregister-event",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/update-formatdata.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/update-formatdata",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/update-typedata.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/update-typedata",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/wait-debugger.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/wait-debugger",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/wait-event.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/wait-event",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/write-debug.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/write-debug",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/write-error.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/write-error",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/write-host.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/write-host",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/write-information.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/write-information",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/write-output.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/write-output",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/write-progress.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/write-progress",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/write-verbose.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/write-verbose",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.powershell.utility/write-warning.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.utility/write-warning",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/connect-wsman.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/connect-wsman",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/disable-wsmancredssp.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/disable-wsmancredssp",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/disconnect-wsman.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/disconnect-wsman",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/enable-wsmancredssp.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/enable-wsmancredssp",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/get-wsmancredssp.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/get-wsmancredssp",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/get-wsmaninstance.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/get-wsmaninstance",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/invoke-wsmanaction.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/invoke-wsmanaction",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/microsoft.wsman.management.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/new-wsmaninstance.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/new-wsmaninstance",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/new-wsmansessionoption.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/new-wsmansessionoption",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/remove-wsmaninstance.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/remove-wsmaninstance",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/set-wsmaninstance.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/set-wsmaninstance",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/set-wsmanquickconfig.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/set-wsmanquickconfig",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/test-wsman.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/test-wsman",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/microsoft.wsman.management/wsman-provider.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/about/about_wsman_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/packagemanagement.md",
+      "redirect_url": "/powershell/module/packagemanagement/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/packagemanagement/find-package.md",
+      "redirect_url": "/powershell/module/packagemanagement/find-package",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/packagemanagement/find-packageprovider.md",
+      "redirect_url": "/powershell/module/packagemanagement/find-packageprovider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/packagemanagement/get-package.md",
+      "redirect_url": "/powershell/module/packagemanagement/get-package",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/packagemanagement/get-packageprovider.md",
+      "redirect_url": "/powershell/module/packagemanagement/get-packageprovider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/packagemanagement/get-packagesource.md",
+      "redirect_url": "/powershell/module/packagemanagement/get-packagesource",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/packagemanagement/import-packageprovider.md",
+      "redirect_url": "/powershell/module/packagemanagement/import-packageprovider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/packagemanagement/install-package.md",
+      "redirect_url": "/powershell/module/packagemanagement/install-package",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/packagemanagement/install-packageprovider.md",
+      "redirect_url": "/powershell/module/packagemanagement/install-packageprovider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/packagemanagement/packagemanagement.md",
+      "redirect_url": "/powershell/module/packagemanagement/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/packagemanagement/register-packagesource.md",
+      "redirect_url": "/powershell/module/packagemanagement/register-packagesource",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/packagemanagement/save-package.md",
+      "redirect_url": "/powershell/module/packagemanagement/save-package",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/packagemanagement/set-packagesource.md",
+      "redirect_url": "/powershell/module/packagemanagement/set-packagesource",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/packagemanagement/uninstall-package.md",
+      "redirect_url": "/powershell/module/packagemanagement/uninstall-package",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/packagemanagement/unregister-packagesource.md",
+      "redirect_url": "/powershell/module/packagemanagement/unregister-packagesource",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget.md",
+      "redirect_url": "/powershell/module/powershellget/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/find-command.md",
+      "redirect_url": "/powershell/module/powershellget/find-command",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/find-dscresource.md",
+      "redirect_url": "/powershell/module/powershellget/find-dscresource",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/find-module.md",
+      "redirect_url": "/powershell/module/powershellget/find-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/find-rolecapability.md",
+      "redirect_url": "/powershell/module/powershellget/find-rolecapability",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/find-script.md",
+      "redirect_url": "/powershell/module/powershellget/find-script",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/get-installedmodule.md",
+      "redirect_url": "/powershell/module/powershellget/get-installedmodule",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/get-installedscript.md",
+      "redirect_url": "/powershell/module/powershellget/get-installedscript",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/get-psrepository.md",
+      "redirect_url": "/powershell/module/powershellget/get-psrepository",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/install-module.md",
+      "redirect_url": "/powershell/module/powershellget/install-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/install-script.md",
+      "redirect_url": "/powershell/module/powershellget/install-script",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/new-scriptfileinfo.md",
+      "redirect_url": "/powershell/module/powershellget/new-scriptfileinfo",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/powershellget.md",
+      "redirect_url": "/powershell/module/powershellget/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/publish-module.md",
+      "redirect_url": "/powershell/module/powershellget/publish-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/publish-script.md",
+      "redirect_url": "/powershell/module/powershellget/publish-script",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/register-psrepository.md",
+      "redirect_url": "/powershell/module/powershellget/register-psrepository",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/save-module.md",
+      "redirect_url": "/powershell/module/powershellget/save-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/save-script.md",
+      "redirect_url": "/powershell/module/powershellget/save-script",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/set-psrepository.md",
+      "redirect_url": "/powershell/module/powershellget/set-psrepository",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/test-scriptfileinfo.md",
+      "redirect_url": "/powershell/module/powershellget/test-scriptfileinfo",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/uninstall-module.md",
+      "redirect_url": "/powershell/module/powershellget/uninstall-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/uninstall-script.md",
+      "redirect_url": "/powershell/module/powershellget/uninstall-script",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/unregister-psrepository.md",
+      "redirect_url": "/powershell/module/powershellget/unregister-psrepository",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/update-module.md",
+      "redirect_url": "/powershell/module/powershellget/update-module",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/update-modulemanifest.md",
+      "redirect_url": "/powershell/module/powershellget/update-modulemanifest",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/update-script.md",
+      "redirect_url": "/powershell/module/powershellget/update-script",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/powershellget/update-scriptfileinfo.md",
+      "redirect_url": "/powershell/module/powershellget/update-scriptfileinfo",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psdesiredstateconfiguration.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psdesiredstateconfiguration/about/about_classes_and_dsc.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/about/about_classes_and_dsc",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psdesiredstateconfiguration/get-dscresource.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/get-dscresource",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psdesiredstateconfiguration/new-dscchecksum.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/new-dscchecksum",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psdesiredstateconfiguration/psdesiredstateconfiguration.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psdiagnostics/disable-pstrace.md",
+      "redirect_url": "/powershell/module/psdiagnostics/disable-pstrace",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psdiagnostics/disable-pswsmancombinedtrace.md",
+      "redirect_url": "/powershell/module/psdiagnostics/disable-pswsmancombinedtrace",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psdiagnostics/disable-wsmantrace.md",
+      "redirect_url": "/powershell/module/psdiagnostics/disable-wsmantrace",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psdiagnostics/enable-pstrace.md",
+      "redirect_url": "/powershell/module/psdiagnostics/enable-pstrace",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psdiagnostics/enable-pswsmancombinedtrace.md",
+      "redirect_url": "/powershell/module/psdiagnostics/enable-pswsmancombinedtrace",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psdiagnostics/enable-wsmantrace.md",
+      "redirect_url": "/powershell/module/psdiagnostics/enable-wsmantrace",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psdiagnostics/get-logproperties.md",
+      "redirect_url": "/powershell/module/psdiagnostics/get-logproperties",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psdiagnostics/psdiagnostics.md",
+      "redirect_url": "/powershell/module/psdiagnostics/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psdiagnostics/set-logproperties.md",
+      "redirect_url": "/powershell/module/psdiagnostics/set-logproperties",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psdiagnostics/start-trace.md",
+      "redirect_url": "/powershell/module/psdiagnostics/start-trace",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psdiagnostics/stop-trace.md",
+      "redirect_url": "/powershell/module/psdiagnostics/stop-trace",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psreadline.md",
+      "redirect_url": "/powershell/module/psreadline/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psreadline/get-psreadlinekeyhandler.md",
+      "redirect_url": "/powershell/module/psreadline/get-psreadlinekeyhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psreadline/get-psreadlineoption.md",
+      "redirect_url": "/powershell/module/psreadline/get-psreadlineoption",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psreadline/psconsolehostreadline.md",
+      "redirect_url": "/powershell/module/psreadline/psconsolehostreadline",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psreadline/psreadline.md",
+      "redirect_url": "/powershell/module/psreadline/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psreadline/remove-psreadlinekeyhandler.md",
+      "redirect_url": "/powershell/module/psreadline/remove-psreadlinekeyhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psreadline/set-psreadlinekeyhandler.md",
+      "redirect_url": "/powershell/module/psreadline/set-psreadlinekeyhandler",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/psreadline/set-psreadlineoption.md",
+      "redirect_url": "/powershell/module/psreadline/set-psreadlineoption",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/6/readme.md",
+      "redirect_url": "/powershell/scripting/overview",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/microsoft.powershell.core/about.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/microsoft.powershell.core/alias-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_alias_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/microsoft.powershell.core/environment-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_environment_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/microsoft.powershell.core/filesystem-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_filesystem_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/microsoft.powershell.core/function-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_function_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/microsoft.powershell.core/providers/alias-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_alias_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/microsoft.powershell.core/providers/environment-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_environment_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/microsoft.powershell.core/providers/filesystem-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_filesystem_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/microsoft.powershell.core/providers/function-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_function_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/microsoft.powershell.core/providers/registry-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_registry_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/microsoft.powershell.core/providers/variable-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_variable_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/microsoft.powershell.core/registry-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_registry_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/microsoft.powershell.core/variable-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.core/about/about_variable_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/microsoft.powershell.security/certificate-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/about/about_certificate_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/microsoft.powershell.security/providers/certificate-provider.md",
+      "redirect_url": "/powershell/module/microsoft.powershell.security/about/about_certificate_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/microsoft.wsman.management/about_ws-management_cmdlets.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/about/about_ws-management_cmdlets",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/microsoft.wsman.management/providers/wsman-provider.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/about/about_wsman_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/microsoft.wsman.management/wsman-provider.md",
+      "redirect_url": "/powershell/module/microsoft.wsman.management/about/about_wsman_provider",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/psdesiredstateconfiguration/about_classes_and_dsc.md",
+      "redirect_url": "/powershell/module/psdesiredstateconfiguration/about/about_classes_and_dsc",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/psscheduledjob/about_scheduled_jobs.md",
+      "redirect_url": "/powershell/module/psscheduledjob/about/about_scheduled_jobs",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/psscheduledjob/about_scheduled_jobs_advanced.md",
+      "redirect_url": "/powershell/module/psscheduledjob/about/about_scheduled_jobs_advanced",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/psscheduledjob/about_scheduled_jobs_basics.md",
+      "redirect_url": "/powershell/module/psscheduledjob/about/about_scheduled_jobs_basics",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/psscheduledjob/about_scheduled_jobs_troubleshooting.md",
+      "redirect_url": "/powershell/module/psscheduledjob/about/about_scheduled_jobs_troubleshooting",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/psworkflow/about_activitycommonparameters.md",
+      "redirect_url": "/powershell/module/psworkflow/about/about_activitycommonparameters",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/psworkflow/about_checkpoint-workflow.md",
+      "redirect_url": "/powershell/module/psworkflow/about/about_checkpoint-workflow",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/psworkflow/about_foreach-parallel.md",
+      "redirect_url": "/powershell/module/psworkflow/about/about_foreach-parallel",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/psworkflow/about_inlinescript.md",
+      "redirect_url": "/powershell/module/psworkflow/about/about_inlinescript",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/psworkflow/about_parallel.md",
+      "redirect_url": "/powershell/module/psworkflow/about/about_parallel",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/psworkflow/about_sequence.md",
+      "redirect_url": "/powershell/module/psworkflow/about/about_sequence",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/psworkflow/about_suspend-workflow.md",
+      "redirect_url": "/powershell/module/psworkflow/about/about_suspend-workflow",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/psworkflow/about_workflowcommonparameters.md",
+      "redirect_url": "/powershell/module/psworkflow/about/about_workflowcommonparameters",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/psworkflow/about_workflows.md",
+      "redirect_url": "/powershell/module/psworkflow/about/about_workflows",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "reference/virtual-directory-module/readme.md",
+      "redirect_url": "/powershell/scripting/overview",
+      "redirect_document_id": false
+    }
+  ]
 }


### PR DESCRIPTION
# PR Summary
- [x] [AB#284578](https://dev.azure.com/ceapex/Engineering/_workitems/edit/284578): yml redirections not supported in v2

## PR Context
  - `.yml` redirections with document_id are not supported in v2, they are exactly the same as setting to `false` .
  - In order not to change the generated document_id during migration, they need to be turned to `false`. 
  - However, the redirect_document_id: true will be supported after migrated to `docfx-v3`.
